### PR TITLE
Round 5

### DIFF
--- a/lib/internal/http2.js
+++ b/lib/internal/http2.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const http2 = process.binding('http2');
+const timers = require('timers');
 const util = require('util');
 const Buffer = require('buffer').Buffer;
 const EventEmitter = require('events');
@@ -8,32 +9,31 @@ const internalHttp = require('internal/http');
 const TLSServer = require('tls').Server;
 const NETServer = require('net').Server;
 const stream = require('stream');
-const BufferList = require('internal/streams/BufferList');
+const WriteWrap = process.binding('stream_wrap').WriteWrap;
+const ShutdownWrap = process.binding('stream_wrap').ShutdownWrap;
+const uv = process.binding('uv');
 const Writable = stream.Writable;
-const PassThrough = stream.PassThrough;
+const Readable = stream.Readable;
+const Duplex = stream.Duplex;
 const constants = http2.constants;
 const utcDate = internalHttp.utcDate;
 
+const kStatusCode = Symbol('status-code');
 const kOptions = Symbol('options');
 const kStream = Symbol('stream');
 const kHeaders = Symbol('headers');
 const kHeadersSent = Symbol('headers-sent');
-const kTrailersSent = Symbol('trailers-sent');
 const kSession = Symbol('session');
 const kRequest = Symbol('request');
 const kResponse = Symbol('response');
 const kFinished = Symbol('finished');
 const kTrailers = Symbol('trailers');
-const kChunks = Symbol('chunks');
-const kProvider = Symbol('provider');
 const kResume = Symbol('resume');
 const kBeginSend = Symbol('begin-send');
-const kEndStream = Symbol('end-stream');
-const kHasTrailers = Symbol('has-trailers');
 const kInFlight = Symbol('in-flight');
-const kExpectContinue = Symbol('expect-continue');
-const kResponseFlags = Symbol('response-flags');
-const kResponseFlag_SendDate = 0x1;
+const kSendDate = Symbol('send-date');
+const kDetached = Symbol('detached');
+const kNoBody = Symbol('nobody')
 
 const kDefaultSocketTimeout = 2 * 60 * 1000;
 const kRenegTest = /TLS session renegotiation disabled for this socket/;
@@ -44,37 +44,286 @@ Object.defineProperty(exports, 'constants', {
   value: constants
 });
 
-// The process.binding('http2').Http2Session object will
-// emit events as callbacks. To allow this to happen,
-// it has to inherit from EventEmitter.
 util.inherits(http2.Http2Session, EventEmitter);
+util.inherits(http2.Http2Stream, Duplex);
 
+function prepareStream(stream) {
+  Duplex.call(stream);
+  stream.on('detach', () => {
+    this[kDetached] = true;
+    stream.end();
+  });
+}
 
-http2.Http2Session.prototype.gracefulTerminate = function(callback, code) {
-  if (typeof callback !== 'function')
-    throw new TypeError('callback must be a function');
-    // Begin graceful termination process. See:
-    // https://nghttp2.org/documentation/nghttp2_submit_shutdown_notice.html
-    // For detail. This process results in sending two GOAWAY frames to the
-    // client. The second one is the actual GOAWAY that will terminate the
-    // session. The second terminate and the passed in callback are invoked
-    // on nextTick (TODO(jasnell): setImmediate might be better)).
-  if (this.startGracefulTerminate() >= 0) {
-    process.nextTick(() => {
-      this.terminate(code || constants.NGHTTP2_NO_ERROR);
-      callback();
-    });
+// TODO(jasnell):
+// There are three key states that need to be tracked: (1) Is the Http2Stream
+// attached to the underlying Http2Session (e.g. that is, is the internal
+// nghttp2_stream handle still valid), (2) Is the Http2Stream Duplex interface
+// still Writable, and (3) Is the Http2Stream Duplex still Readable. The
+// Http2Stream object cannot be disposed of and garbage collected until all
+// three of those states are false. Because of async reads/writes on the Duplex
+// interface, it's possible for the Http2Stream to become detached from the
+// underlying Http2Session. Ideally, when that happens both the Readable and
+// Writable sides will close and any internally buffered data would be dropped
+// and additional writes will fail but I do not have that completely wired up
+// yet. The maybeDestroyStream(stream) check is largely a temporary stopgap to
+// determine when the Writable and Readable sides are closed so that we can
+// allow the Http2Stream to be garbage collected.
+function maybeDestroyStream(stream) {
+  // if ((!stream.readable &&
+  //      !stream.writable &&
+  //      !stream._writableState.length)) {
+  if ((!stream.writable &&
+       !stream._writableState.length)) {
+    timers.unenroll(stream);
+    stream.destroy();
   }
+}
+
+// Called by the internal Http2Stream class when data has been read
+// and is being made available. This method is *not* part of the
+// public JS API of the Http2Stream object and should not be called
+// by anyone other than the internal HttpStream class. The defineProperty
+// call below intentionally makes the onread callback non-enumerable,
+// non-configurable and read-only in order to keep userland from altering
+// the expected behavior through monkey-patching.
+Object.defineProperty(http2.Http2Stream.prototype, 'onread', {
+  configurable: false,
+  enumerable: false,
+  value: onread
+});
+function onread(nread, buffer) {
+  const stream = this;
+
+  unrefTimer(this);
+
+  if (nread > 0) {
+    var ret = stream.push(buffer);
+    if (stream.reading && !ret) {
+      stream.reading = false;
+      var err = stream.readStop();
+      if (err) {
+        // TODO(jasnell): figure this out
+        maybeDestroyStream(stream);
+      }
+    }
+    return;
+  }
+
+  if (nread === 0) {
+    return;
+  }
+
+  if (nread !== uv.UV_EOF) {
+    // TODO(jasnell): figure out
+    return maybeDestroyStream(stream);
+  }
+
+  stream.push(null);
+
+  if (stream._readableState.length === 0) {
+    stream.readable = false;
+    // TODO(jasnell): Figure out
+    //maybeDestroy(self);
+  }
+}
+
+http2.Http2Stream.prototype.refuse = function refuse() {
+  this.sendRstStream(constants.NGHTTP2_REFUSED_STREAM);
 };
 
+http2.Http2Stream.prototype.cancel = function cancel() {
+  this.sendRstStream(constants.NGHTTP2_CANCEL);
+};
+
+http2.Http2Stream.prototype.protocolError = function protocolError() {
+  this.sendRstStream(constants.NGHTTP2_PROTOCOL_ERROR);
+};
+
+// Individual Http2Stream instances can have their own activity timeouts
+// that operate in a manner that is identical to socket timeouts. The
+// key thing to remember with these is that for every set timeout there
+// is a Timer controlling it.
+
+function unrefTimer(item) {
+  timers._unrefActive(item);
+}
+
+http2.Http2Stream.prototype.setTimeout = function(msecs, callback) {
+  if (msecs === 0) {
+    timers.unenroll(this);
+    if (callback) {
+      this.removeListener('timeout', callback);
+    }
+  } else {
+    timers.enroll(this, msecs);
+    timers._unrefActive(this);
+    if (callback) {
+      this.once('timeout', callback);
+    }
+  }
+  return this;
+};
+
+function afterShutdown(status, handle, req) {
+  // After shutdown, wait a tick before possibly destroying the
+  // Http2Stream instance. This allows any pending writes to
+  // be dispatched.
+  process.nextTick(() => maybeDestroyStream(handle));
+}
+
+// End the Writable side of the Http2Stream Duplex.
+http2.Http2Stream.prototype.end = function(chunk, encoding, callback) {
+  // Unnecessary to end twice
+  const state = this._writableState;
+  if (state.ending || state.finished) {
+    return;
+  }
+
+  Duplex.prototype.end.call(this, chunk, encoding, callback);
+
+  // Once ended, let the internal Http2Class know that writing
+  // has ended. This allows proper termination of the sequence
+  // of DATA frames being fed into the underlying nghttp2_session
+  const req = new ShutdownWrap();
+  req.oncomplete = afterShutdown;
+  req.handle = this;
+  this.shutdown(req);
+};
+
+http2.Http2Stream.prototype._read = function(size) {
+  this.reading = true;
+  this.readStart();
+};
+
+function afterDoStreamWrite(status, handle, req) {
+  unrefTimer(handle);
+}
+
+function createWriteReq(req, handle, data, encoding) {
+  switch (encoding) {
+    case 'latin1':
+    case 'binary':
+      return handle.writeLatin1String(req, data);
+
+    case 'buffer':
+      return handle.writeBuffer(req, data);
+
+    case 'utf8':
+    case 'utf-8':
+      return handle.writeUtf8String(req, data);
+
+    case 'ascii':
+      return handle.writeAsciiString(req, data);
+
+    case 'ucs2':
+    case 'ucs-2':
+    case 'utf16le':
+    case 'utf-16le':
+      return handle.writeUcs2String(req, data);
+
+    default:
+      return handle.writeBuffer(req, Buffer.from(data, encoding));
+  }
+}
+
+http2.Http2Stream.prototype._writev = function(chunks, cb) {
+  unrefTimer(stream);
+  const req = new WriteWrap();
+  req.handle = this;
+  req.oncomplete = afterDoStreamWrite;
+  req.async = false;
+  var err;
+
+  const data = new Array(chunks.length << 1);
+  for (var i = 0; i < chunks.length; i++) {
+    const entry = data[i];
+    data[i * 2] = entry.chunk;
+    data[i * 2 + 1] = entry.encoding;
+  }
+  err = this.writev(req, data);
+
+  // Retain chunks
+  if (err === 0) req._chunks = data;
+
+  if (err) {
+    throw util._errnoException(err, 'write', req.error);
+  }
+
+  this._bytesDispatched += req.bytes;
+
+  cb();
+};
+
+http2.Http2Stream.prototype._write = function(data, encoding, cb) {
+  unrefTimer(stream);
+  const req = new WriteWrap();
+  req.handle = this;
+  req.oncomplete = afterDoStreamWrite;
+  req.async = false;
+  var err;
+
+  var enc;
+  if (data instanceof Buffer) {
+    enc = 'buffer';
+  } else {
+    enc = encoding;
+  }
+  err = createWriteReq(req, this, data, enc);
+
+  if (err) {
+    throw util._errnoException(err, 'write', req.error);
+  }
+
+  this._bytesDispatched += req.bytes;
+
+  cb();
+};
+
+// Begin graceful termination process. See:
+// https://nghttp2.org/documentation/nghttp2_submit_shutdown_notice.html
+// For detail. This process results in sending two GOAWAY frames to the
+// client. The second one is the actual GOAWAY that will terminate the
+// session. The second terminate and the passed in callback are invoked
+// on nextTick (TODO(jasnell): setImmediate might be better)).
+http2.Http2Session.prototype.gracefulTerminate = function(code, callback) {
+  if (typeof code === 'function') {
+    callback = code;
+    code = undefined;
+  }
+  if (typeof callback !== 'function')
+    throw new TypeError('callback must be a function');
+
+  this.startGracefulTerminate();
+  process.nextTick(() => {
+    this.terminate(code || constants.NGHTTP2_NO_ERROR);
+    callback();
+  });
+};
+
+function initHttp2IncomingOptions(options) {
+  // TODO(jasnell): It might make sense to set the default highWaterMark
+  // for Incoming Streams to the configured Max Frame Size, this would
+  // ensure that the stream buffer could at least consume a single complete
+  // data frames worth of data
+  options = options || {};
+  return options;
+}
+
+function initHttp2OutgoingOptions(options) {
+  options = options || {};
+  return options;
+}
 
 // Represents an incoming HTTP/2 message.
-// TODO(jasnell): This should not be a PassThrough. It needs to be
-// just a Readable so that the Writable methods are not accessible
-// to users. For now, this is the easiest thing to just get it working.
-class Http2Incoming extends PassThrough {
-  constructor(stream, headers) {
-    super({});
+// TODO(jasnell): This is currently incomplete
+class Http2Incoming extends Readable {
+  constructor(stream, headers, options) {
+    super(initHttp2IncomingOptions(options));
+    if (!(stream instanceof http2.Http2Stream))
+      throw new TypeError('stream argument must be an Http2Stream instance');
+    if (!(headers instanceof Map))
+      throw new TypeError('headers argument must be a Map');
     this[kStream] = stream;
     this[kHeaders] = headers;
     this[kFinished] = false;
@@ -104,18 +353,22 @@ class Http2Incoming extends PassThrough {
     return this[kFinished];
   }
 
+  // Set the timeout on the underlying Http2Stream object
   setTimeout(msecs, callback) {
-    if (callback)
-      this.on('timeout', callback);
-    this.socket.setTimeout(msecs);
+    if (!this.stream) return;
+    this.stream.setTimeout(msecs, callback);
     return this;
+  }
+
+  _read(n) {
+    // TODO(@jasnell)
   }
 }
 
-
+// Represents an incoming HTTP Request on the Server.
 class Http2ServerRequest extends Http2Incoming {
-  constructor(stream, headers) {
-    super(stream, headers);
+  constructor(stream, headers, options) {
+    super(stream, headers, options);
   }
 
   get method() {
@@ -135,27 +388,6 @@ class Http2ServerRequest extends Http2Incoming {
   }
 }
 
-function getProvider(outgoing) {
-  const provider = new http2.Http2DataProvider();
-  provider._read = (buffer, flags) => {
-    const chunks = outgoing[kChunks];
-    if (chunks.length === 0) {
-      if (!outgoing[kFinished]) {
-        return constants.NGHTTP2_ERR_DEFERRED;
-      } else {
-        outgoing[kEndStream](flags);
-        return 0;
-      }
-    } else {
-      if (outgoing[kFinished])
-        outgoing[kEndStream](flags);
-      const ret = copyBuffers(buffer, chunks);
-      return ret;
-    }
-  };
-  return provider;
-}
-
 function onHttp2OutgoingPipe() {
   if (this[kHeadersSent])
     this[kResume]();
@@ -163,17 +395,13 @@ function onHttp2OutgoingPipe() {
     this[kBeginSend]();
 }
 
+// Represents an outbound HTTP message.
 class Http2Outgoing extends Writable {
-  constructor(stream) {
-    super({});
+  constructor(stream, options) {
+    super(initHttp2OutgoingOptions(options));
     this[kStream] = stream;
-    this[kHeaders] = new Map();
-    this[kTrailers] = new Map();
     this[kFinished] = false;
     this[kHeadersSent] = false;
-    this[kTrailersSent] = false;
-    this[kChunks] = new BufferList();
-    this[kProvider] = getProvider(this);
     this.on('pipe', onHttp2OutgoingPipe);
   }
 
@@ -189,155 +417,95 @@ class Http2Outgoing extends Writable {
     return this[kHeadersSent];
   }
 
-  get trailersSent() {
-    return this[kTrailersSent];
-  }
-
-  setHeader(name, value) {
-    // TODO(jasnell): Enable the following check later
-    // if (this.headersSent)
-    //   throw new Error('Cannot set headers after they are sent');
+  setHeader(name, value, noindex) {
+    if (this.headersSent)
+      throw new Error(
+        'Cannot set headers after the HTTP message has been sent');
+    if (!this.stream)
+      throw new Error('Cannot set header on a closed stream');
     name = String(name).toLowerCase().trim();
     if (isPseudoHeader(name))
       throw new Error('Cannot set HTTP/2 pseudo-headers');
     if (isIllegalConnectionSpecificHeader(name, value))
-      throw new Error('Connection-specific HTTP headers are not permitted');
-    // Delete the current value if it's null
+      throw new Error('Connection-specific HTTP/1 headers are not permitted');
     if (value === undefined || value === null) {
-      this[kHeaders].delete(name);
-      return this;
+      throw new TypeError('Value must not be undefined or null');
     }
-
-    if (Array.isArray(value)) {
-      this[kHeaders].set(name, value.map((i) => String(i)));
-    } else {
-      this[kHeaders].set(name, String(value));
-    }
+    this.stream.addHeader(name, value, Boolean(noindex));
     return this;
   }
 
-  setTrailer(name, value) {
-    if (this.trailersSent)
-      throw new Error('Cannot set trailers after they are sent');
+  setTrailer(name, value, noindex) {
+    if (this.headersSent)
+      throw new Error(
+        'Cannot set trailers after the HTTP message has been sent');
+    if (!this.stream)
+      throw new Error('Cannot set trailer on a closed stream');
     name = String(name).toLowerCase().trim();
     if (isPseudoHeader(name))
       throw new Error('Cannot set HTTP/2 pseudo-headers');
     if (isIllegalConnectionSpecificHeader(name, value))
-      throw new Error('Connection-specific HTTP headers are not permitted');
-    // Delete the current value if it's null
+      throw new Error('Connection-specific HTTP/1 headers are not permitted');
     if (value === undefined || value === null) {
-      this[kTrailers].delete(name);
-      return this;
+      throw new TypeError('Value must not be undefined or null');
     }
-
-    if (Array.isArray(value)) {
-      this[kTrailers].set(name, value.map((i) => String(i)));
-    } else {
-      this[kTrailers].set(name, String(value));
-    }
+    this.stream.addTrailer(name, value, Boolean(noindex));
     return this;
   }
 
   addHeaders(headers) {
-    for (const key of headers)
+    if (!headers) return;
+    const keys = Object.keys(headers);
+    for (const key of keys)
       this.setHeader(key, headers[key]);
     return this;
   }
 
   addTrailers(headers) {
-    for (const key of headers)
+    if (!headers) return;
+    const keys = Object.keys(headers);
+    for (const key of keys)
       this.setTrailer(key, headers[key]);
     return this;
   }
 
-  getHeader(name) {
-    return this[kHeaders].get(name);
-  }
-
-  getTrailer(name) {
-    return this[kTrailers].get(name);
-  }
-
-  removeHeader(name) {
-    if (this.headersSent)
-      throw new Error('Cannot remove headers after they are sent');
-    this[kHeaders].delete(name);
-    return this;
-  }
-
-  removeTrailer(name) {
-    if (this.trailersSent)
-      throw new Error('Cannot remove trailers after they are sent');
-    this[kTrailers].delete(name);
-    return this;
-  }
-
+  // Set the timeout on the underlying Http2Stream object
   setTimeout(msecs, callback) {
-    if (callback)
-      this.on('timeout', callback);
-    if (!this.socket) {
-      this.once('socket', (socket) => socket.setTimeout(msecs));
-    } else {
-      this.socket.setTimeout(msecs);
-    }
+    if (!this.stream) return;
+    this.stream.setTimeout(msecs, callback);
     return this;
-  }
-
-  _writev(chunks, callback) {
-    const state = this.stream ? this.stream.state :
-                                constants.NGHTTP2_STREAM_STATE_CLOSED;
-    if (state !== constants.NGHTTP2_STREAM_STATE_CLOSED &&
-        state !== constants.NGHTTP2_STREAM_STATE_HALF_CLOSED_LOCAL) {
-      for (var n = 0; n < chunks.length; n++)
-        this[kChunks].push(chunks[n]);
-      if (this[kHeadersSent])
-        this[kResume]();
-      else
-        this[kBeginSend]();
-    } else {
-      this[kFinished] = true;
-      super.end();
-    }
-    callback();
   }
 
   _write(chunk, encoding, callback) {
     if (typeof chunk === 'string')
       chunk = Buffer.from(chunk, encoding);
-
-    const state = this.stream ? this.stream.state :
-                                constants.NGHTTP2_STREAM_STATE_CLOSED;
-    if (state !== constants.NGHTTP2_STREAM_STATE_CLOSED &&
-        state !== constants.NGHTTP2_STREAM_STATE_HALF_CLOSED_LOCAL) {
-      if (chunk.length > 0)
-        this[kChunks].push(chunk);
-      if (this[kHeadersSent])
+    if (this.stream) {
+      this[kBeginSend]();
+      this.stream.write(chunk, encoding, () => {
         this[kResume]();
-      else
-        this[kBeginSend]();
+        if (typeof callback === 'function')
+          callback();
+      });
     } else {
       this[kFinished] = true;
-      super.end();
+      callback();
     }
-    callback();
   }
 
   end(data, encoding, callback) {
-    if (this[kFinished])
-      return false;
-    this[kFinished] = true;
-    const ret = super.end(data, encoding, callback);
-    if (this[kHeadersSent])
-      this[kResume]();
-    else
+    if (this.stream) {
       this[kBeginSend]();
-    return ret;
+      this[kFinished] = true;
+      this.stream.end(data, encoding, callback);
+      return;
+    }
+    throw new Error('write after end');
   }
 
   [kBeginSend]() {
     if (!this[kHeadersSent]) {
       this[kHeadersSent] = true;
-      this.stream.respond(mapToHeaders(this[kHeaders]), this[kProvider]);
+      this.stream.respond(Boolean(this[kNoBody]));
     }
   }
 
@@ -346,43 +514,27 @@ class Http2Outgoing extends Writable {
       this.stream.resumeData();
     }
   }
-
-  [kEndStream](flags) {
-    this[kTrailersSent] = true;
-    flags[constants.FLAG_ENDDATA] = true;
-    // TODO(jasnell): kHasTrailers is currently not set anywhere
-    if (this[kHasTrailers]) {
-      flags[constants.FLAG_NOENDSTREAM] = true;
-      const stream = this.stream;
-      stream.sendTrailers(mapToHeaders(this[kTrailers]));
-    } else {
-      flags[constants.FLAG_ENDSTREAM] = true;
-    }
-    this[kProvider] = null;
-  }
 }
 
-
+// Represents an HTTP/2 server response message
 class Http2ServerResponse extends Http2Outgoing {
-  constructor(stream) {
-    super(stream);
-    this[kResponseFlags] = kResponseFlag_SendDate;
-    this.statusCode = constants.HTTP_STATUS_OK;
+  constructor(stream, options) {
+    super(stream, options);
+    this[kStatusCode] = constants.HTTP_STATUS_OK;
+    this[kSendDate] = true;
+    this[kOptions] = options;
   }
 
   get sendDate() {
-    return (this[kResponseFlags] & kResponseFlag_SendDate) ===
-           kResponseFlag_SendDate;
+    return this[kSendDate];
   }
 
   set sendDate(bool) {
-    bool = Boolean(bool);
-    if (bool) this[kResponseFlags] |= kResponseFlag_SendDate;
-    else this[kResponseFlags] &= ~kResponseFlag_SendDate;
+    this[kSendDate] = Boolean(bool);
   }
 
   get statusCode() {
-    this[kHeaders].get(constants.HTTP2_HEADER_STATUS);
+    return this[kStatusCode];
   }
 
   set statusCode(code) {
@@ -393,26 +545,40 @@ class Http2ServerResponse extends Http2Outgoing {
         ' is not supported by HTTP/2');
     if (code < 100 || code > 999)
       throw new RangeError(`Invalid status code: ${code}`);
-    this[kHeaders].set(constants.HTTP2_HEADER_STATUS, code);
-  }
-
-  writeContinue() {
-    this[kStream].sendContinue();
-  }
-
-  writeHead(statusCode, headers) {
-    this.statusCode = statusCode || constants.HTTP_STATUS_OK;
-    if (headers) {
-      const keys = Object.keys(headers);
-      for (var key of keys)
-        this.setHeader(key, headers[key]);
-    }
-    return this;
+    this[kStatusCode] = code;
   }
 
   get pushSupported() {
     if (!this.stream) return false;
     return this.stream.session.remoteSettings.enablePush;
+  }
+
+  writeContinue() {
+    if (this.stream) {
+      this.stream.sendContinue();
+    }
+  }
+
+  // TODO(jasnell): It would be useful to have a variation on writeHead
+  // that causes the Writable side to close automatically in the case
+  // where there is no data to send. This would allow us to optimize
+  // the HTTP/2 frames by only sending the response HEADERS frame and
+  // no DATA frames. Otherwise, the current API would result in have to
+  // send at least one possibly empty DATA frame every time...
+  //
+  // Note: the nobody arg is a temporary way of handling no-body responses.
+  // I will be refactoring this API but I wanted a way to experiment with
+  // the approach a bit.
+  writeHead(statusCode, headers, nobody) {
+    if (typeof statusCode === 'object') {
+      headers = statusCode;
+      statusCode = constants.HTTP_STATUS_OK;
+    }
+    this.statusCode = statusCode || constants.HTTP_STATUS_OK;
+    this.addHeaders(headers);
+    if (nobody)
+      this[kNoBody] = true;
+    return this;
   }
 
   createPushResponse() {
@@ -426,12 +592,17 @@ class Http2ServerResponse extends Http2Outgoing {
   }
 
   [kBeginSend]() {
-    if (!this[kHeadersSent] && this.sendDate)
-      this.setHeader('date', utcDate());
+    if (!this[kHeadersSent]) {
+      this.stream.addHeader(constants.HTTP2_HEADER_STATUS, this.statusCode);
+      if (this.sendDate)
+        this.setHeader('date', utcDate());
+    }
     super[kBeginSend]();
   }
 }
 
+// Http2PushResponse objects are used to prepare push streams.
+// TODO(jasnell): The API on this is still largely undetermined.
 class Http2PushResponse extends EventEmitter {
   constructor(response) {
     super();
@@ -486,11 +657,11 @@ class Http2PushResponse extends EventEmitter {
     const parent = this[kResponse].stream;
     const ret = parent.sendPushPromise(mapToHeaders(this[kHeaders]));
     if (ret) {
-      ret[kRequest] =
-          new Http2ServerRequest(ret, this[kHeaders]);
-      ret[kResponse] = new Http2ServerResponse(ret);
+      prepareStream(ret);
+      ret.readable = false;
+      ret[kRequest] = new Http2ServerRequest(ret, this[kHeaders]);
+      ret[kResponse] = new Http2ServerResponse(ret, ret[kResponse][kOptions]);
       ret[kRequest][kFinished] = true;
-      ret[kRequest].end();
       callback(ret[kRequest], ret[kResponse]);
     }
   }
@@ -507,13 +678,17 @@ function isPseudoHeader(name) {
 // particular, Connection, Upgrade and HTTP2-Settings must not be used
 // within HTTP/2 requests or response messages. Their use must be handled
 // as malformed messages.
-// TODO(jasnell): improve performance on this.
 function isIllegalConnectionSpecificHeader(name, value) {
-  if (/^(?:connection|upgrade|http2-settings)$/i.test(name))
-    return true;
-  if (/^te$/i.test(name) && !/^trailers$/i.test(value))
-    return true;
-  return false;
+  switch (name) {
+    case 'connection':
+    case 'upgrade':
+    case 'http2-settings':
+      return true;
+    case 'te':
+      return value === 'trailers';
+    default:
+      return false;
+  }
 }
 
 // Converts a ES6 map into an http2.Http2Headers object.
@@ -544,40 +719,6 @@ function mapToHeaders(map) {
     }
   }
   return ret;
-}
-
-// Copies data from the given chunks to the buffer, up to buffer.length,
-// Removes the written data from chunks. Returns the total number of
-// bytes copied. This method is called when chunking data into individual
-// HTTP/2 data frames. The buffer represents the total amount of data that
-// can be included in the frame, chunks is the data pending to write to
-// those data frames.
-// TODO(jasnell): Improve performance on this
-function copyBuffers(buffer, list, offset) {
-  // list head will be null if there are no buffers;
-  if (list.length === 0) return 0;
-  offset |= 0;
-  var remaining = buffer.length - offset;
-  var copied = 0;
-  do {
-    // pop the first one;
-    const head = list.shift();
-    if (head.length > remaining) {
-      // the head has more than we need...
-      // copy just a bit, unshift the rest back onto the list... then be done
-      const n = head.copy(buffer, offset, 0, remaining);
-      list.unshift(head.slice(remaining));
-      remaining -= n;
-      copied += n;
-    } else {
-      // head either has exactly what we need or not enough.
-      const n = head.copy(buffer, offset, 0, head.length);
-      offset += n;
-      remaining -= n;
-      copied += n;
-    }
-  } while (list.head && remaining);
-  return copied;
 }
 
 // The HTTP/2 Server Connection Listener. This is used for both the TLS and
@@ -614,41 +755,11 @@ function socketOnDrain() {
   }
 }
 
-function sessionOnDataChunk(stream, flags, chunk) {
-  const request = stream[kRequest];
-  if (!request) {
-    const err = new Error('Invalid Http2Session State');
-    this.emit('error', err);
-    return;
-  }
-  // TODO(jasnell): to properly handle padding, we should actually buffer
-  // this data and not write it to the request until the data-end event is
-  // emitted. See below.
-  request.write(chunk);
-}
-
-function sessionOnData(stream, flags, padding) {
-  const finished = Boolean(flags & constants.NGHTTP2_DATA_FLAG_EOF ||
-                        flags & constants.NGHTTP2_FLAG_END_STREAM);
-  // TODO: How to handle padding???? data-end will be triggered after the
-  // completion of each individual data frame. The spec allows each data
-  // frame to contain additional padding bytes that must be stripped from
-  // the data before passing on to the user. This means that we should not
-  // actually pass the data on to the request until data-end and the padding
-  // can be stripped. To accomplish this, the data-chunk event and this
-  // event need to be modified to buffer the data and strip the padding.
-  const request = stream[kRequest];
-  if (finished) {
-    request[kFinished] = finished;
-    request.end();
-  }
-}
-
 function sessionOnStreamClose(stream, code) {
   const request = stream[kRequest];
   const response = stream[kResponse];
   if (request && !request.finished) {
-    request.end();
+    request.readable = false;
     request[kFinished] = true;
     if (request[kInFlight])
       request.emit('aborted');
@@ -662,6 +773,7 @@ function sessionOnStreamClose(stream, code) {
   response[kStream] = undefined;
   stream[kRequest] = undefined;
   stream[kResponse] = undefined;
+  setImmediate(() => maybeDestroyStream(stream));
 }
 
 function sessionOnError(server, socket) {
@@ -671,7 +783,7 @@ function sessionOnError(server, socket) {
       return;
     }
     socket.destroy(error);
-  };
+  }
   return fn;
 }
 
@@ -710,14 +822,6 @@ function socketOnceError(server) {
   return fn;
 }
 
-function sessionOnSend(socket) {
-  function fn(data) {
-    if (!socket.destroyed)
-      socket.write(data);
-  }
-  return fn;
-}
-
 function sessionOnHeaderComplete(server) {
   function fn(stream, flags, headers, category) {
     const finished = Boolean(flags & constants.NGHTTP2_FLAG_END_STREAM);
@@ -729,9 +833,17 @@ function sessionOnHeaderComplete(server) {
     var response;
     switch (category) {
       case constants.NGHTTP2_HCAT_REQUEST:
+        // This has to be a new stream, bootstrap it...
+        prepareStream(stream);
+
         // header blocks in this category represent a new request.
-        request = stream[kRequest] = new Http2ServerRequest(stream, headers);
-        response = stream[kResponse] = new Http2ServerResponse(stream);
+        request = stream[kRequest] =
+            new Http2ServerRequest(stream,
+                                   headers,
+                                   server[kOptions].defaultIncomingOptions);
+        response = stream[kResponse] =
+            new Http2ServerResponse(stream,
+                                   server[kOptions].defaultOutgoingOptions);
         // finished will be true if the header block included flags to end
         // the stream (such as when sending a GET request). In such cases,
         // mark the kRequest stream finished so no data will be read.
@@ -745,7 +857,6 @@ function sessionOnHeaderComplete(server) {
           // emit the checkContinue event instead of the request event.
           // This behavior matches the current http/1 API.
           if (/^100-continue$/i.test(headers.get('expect'))) {
-            response[kExpectContinue] = true;
             if (server.listenerCount('checkContinue') > 0) {
               request[kInFlight] = true;
               server.emit('checkContinue', request, response);
@@ -783,7 +894,7 @@ function sessionOnHeaderComplete(server) {
             server.emit('connect', request, response);
             request[kInFlight] = undefined;
           } else {
-            stream.sendRstStream(constants.NGHTTP2_REFUSED_STREAM);
+            stream.refuse();
           }
           break;
         }
@@ -798,14 +909,14 @@ function sessionOnHeaderComplete(server) {
           // the initial HEADERS frame that opened the request, without the
           // end stream flag set. Interstitial headers frames are not permitted
           // in the HTTP semantic binding per the HTTP/2 spec
-          stream.sendRstStream(constants.NGHTTP2_PROTOCOL_ERROR);
+          stream.protocolError();
           return;
         }
         // If finished, that means these are trailing headers
         stream[kRequest][kTrailers] = headers;
         break;
       default:
-        stream.sendRstStream(constants.NGHTTP2_PROTOCOL_ERROR);
+        stream.protocolError();
     }
   }
   return fn;
@@ -835,6 +946,7 @@ function connectionListener(socket) {
   socket.destroy = function(error) {
     session.removeAllListeners();
     socket.removeAllListeners();
+    session.destroy();
     socket.destroy = destroySocket;
     destroySocket.call(socket, error);
   };
@@ -842,11 +954,8 @@ function connectionListener(socket) {
   socket.on('resume', socketOnResume);
   socket.on('pause', socketOnPause);
   socket.on('drain', socketOnDrain);
-  session.on('send', sessionOnSend(socket));
   session.on('headers', sessionOnHeaderComplete(this));
-  session.on('data-chunk', sessionOnDataChunk);
-  session.on('data', sessionOnData);
-  session.on('stream-close', sessionOnStreamClose);
+  session.on('streamClose', sessionOnStreamClose);
   session.localSettings = options.settings;
 }
 
@@ -857,6 +966,14 @@ function initializeOptions(options) {
   if (!(options.settings instanceof http2.Http2Settings)) {
     throw new TypeError(
         'options.settings must be an instance of Http2Settings');
+  }
+  if (!options.defaultIncomingOptions ||
+      typeof options.defaultIncomingOptions !== 'object') {
+    options.defaultIncomingOptions = initHttp2IncomingOptions({});
+  }
+  if (!options.defaultOutgoingOptions ||
+     typeof options.defaultOutgoingOptions !== 'object') {
+    options.defaultOutgoingOptions = initHttp2OutgoingOptions({});
   }
   return options;
 }

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -338,7 +338,7 @@ inline char* Environment::http2_socket_buffer() const {
 }
 
 inline void Environment::set_http2_socket_buffer(char* buffer) {
-  CHECK_EQ(http2_socket_buffer_, nullptr); // Should be set only once.
+  CHECK_EQ(http2_socket_buffer_, nullptr);  // Should be set only once.
   http2_socket_buffer_ = buffer;
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -83,6 +83,7 @@ namespace node {
   V(code_string, "code")                                                      \
   V(cwd_string, "cwd")                                                        \
   V(dest_string, "dest")                                                      \
+  V(destroy_string, "destroy")                                                \
   V(detached_string, "detached")                                              \
   V(disposed_string, "_disposed")                                             \
   V(domain_string, "domain")                                                  \
@@ -111,8 +112,10 @@ namespace node {
   V(file_string, "file")                                                      \
   V(fingerprint_string, "fingerprint")                                        \
   V(flags_string, "flags")                                                    \
+  V(goaway_string, "goaway")                                                  \
   V(gid_string, "gid")                                                        \
   V(handle_string, "handle")                                                  \
+  V(headers_string, "headers")                                                \
   V(heap_total_string, "heapTotal")                                           \
   V(heap_used_string, "heapUsed")                                             \
   V(homedir_string, "homedir")                                                \
@@ -184,6 +187,7 @@ namespace node {
   V(replacement_string, "replacement")                                        \
   V(retry_string, "retry")                                                    \
   V(rss_string, "rss")                                                        \
+  V(rststream_string, "rststream")                                            \
   V(serial_string, "serial")                                                  \
   V(scopeid_string, "scopeid")                                                \
   V(sent_shutdown_string, "sentShutdown")                                     \
@@ -200,6 +204,7 @@ namespace node {
   V(stack_string, "stack")                                                    \
   V(status_string, "status")                                                  \
   V(stdio_string, "stdio")                                                    \
+  V(streamclose_string, "streamClose")                                        \
   V(subject_string, "subject")                                                \
   V(subjectaltname_string, "subjectaltname")                                  \
   V(sys_string, "sys")                                                        \

--- a/src/node_crypto_bio.cc
+++ b/src/node_crypto_bio.cc
@@ -335,7 +335,6 @@ size_t NodeBIO::IndexOf(char delim, size_t limit) {
   return max;
 }
 
-
 void NodeBIO::Write(const char* data, size_t size) {
   size_t offset = 0;
   size_t left = size;

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -3,6 +3,7 @@
 #include "nghttp2/nghttp2.h"
 #include "node_http2.h"
 #include "stream_base.h"
+#include "stream_base-inl.h"
 
 #include "async-wrap.h"
 #include "async-wrap-inl.h"
@@ -27,8 +28,6 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
-using v8::Map;
-using v8::MaybeLocal;
 using v8::Name;
 using v8::Number;
 using v8::Object;
@@ -41,7 +40,7 @@ namespace http2 {
 
 // Http2Options statics
 
-#define OPTIONS(obj, V)                                                \
+#define OPTIONS(obj, V)                                                       \
   V(obj, "maxDeflateDynamicTableSize", SetMaxDeflateDynamicTableSize, Uint32) \
   V(obj, "maxReservedRemoteStreams", SetMaxReservedRemoteStreams, Uint32)     \
   V(obj, "maxSendHeaderBlockLength", SetMaxSendHeaderBlockLength, Uint32)     \
@@ -68,6 +67,8 @@ Http2Options::Http2Options(Environment* env, Local<Value> options) {
 
 // Http2Settings statics
 
+// Utility typedef used to abstract getting remote or local
+// settings from the nghttp2_session instance.
 typedef uint32_t(*get_setting)(nghttp2_session* session,
                                nghttp2_settings_id id);
 Http2Settings::Http2Settings(Environment* env,
@@ -78,6 +79,9 @@ Http2Settings::Http2Settings(Environment* env,
   MakeWeak<Http2Settings>(this);
 
   if (session != nullptr) {
+    // When initialized using an existing Http2Session instance,
+    // fetch the currently established settings and fill in the
+    // internal map.
     get_setting fn =
         localSettings ?
             nghttp2_session_get_local_settings :
@@ -105,6 +109,7 @@ void Http2Settings::New(const FunctionCallbackInfo<Value>& args) {
   new Http2Settings(env, args.This());
 }
 
+// Used to fill in the spec defined initial values for each setting.
 void Http2Settings::Defaults(const FunctionCallbackInfo<Value>& args) {
   Http2Settings* settings;
   ASSIGN_OR_RETURN_UNWRAP(&settings, args.Holder());
@@ -119,12 +124,16 @@ void Http2Settings::Defaults(const FunctionCallbackInfo<Value>& args) {
                 DEFAULT_SETTINGS_MAX_FRAME_SIZE);
 }
 
+// Reset the settings object by clearing the internal map
 void Http2Settings::Reset(const FunctionCallbackInfo<Value>& args) {
   Http2Settings* settings;
   ASSIGN_OR_RETURN_UNWRAP(&settings, args.Holder());
   settings->settings_.clear();
 }
 
+// Serializes the settings object into a Buffer instance that
+// would be suitable, for instance, for creating the Base64
+// output for an HTTP2-Settings header field.
 void Http2Settings::Pack(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   HandleScope scope(env->isolate());
@@ -268,76 +277,11 @@ void Http2Settings::SetMaxHeaderListSize(
     settings->Set(NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE, value->Uint32Value());
 }
 
-// Http2Priority statics
 
-// The Http2Priority class wraps the nghttp2_priority_spec struct.
-Http2Priority::Http2Priority(int32_t parent, int32_t weight, bool exclusive) {
-  if (weight < 0) weight = NGHTTP2_DEFAULT_WEIGHT;
-  weight = MAX(MIN(weight, NGHTTP2_MAX_WEIGHT), NGHTTP2_MIN_WEIGHT);
-  nghttp2_priority_spec_init(&spec_, parent, weight, exclusive ? 1 : 0);
-}
+// Http2Headers statics
 
-
-// Http2DataProvider statics
-
-void Http2DataProvider::New(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  if (!args.IsConstructCall())
-    return env->ThrowTypeError("Class constructor Http2DataProvider cannot "
-                               "be invoked without 'new'");
-  new Http2DataProvider(env, args.This());
-}
-
-ssize_t Http2DataProvider::on_read(nghttp2_session* session,
-                                   int32_t stream_id,
-                                   uint8_t* buf,
-                                   size_t length,
-                                   uint32_t* flags,
-                                   nghttp2_data_source* source,
-                                   void* user_data) {
-  Http2DataProvider* provider =
-    static_cast<Http2DataProvider*>(source->ptr);
-  Http2Stream* stream = static_cast<Http2Stream*>(
-    nghttp2_session_get_stream_user_data(session, stream_id));
-  Local<Object> provider_obj = provider->object();
-  Environment* env = provider->env();
-  Isolate* isolate = env->isolate();
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
-
-  Local<Value> cb = provider_obj->Get(FIXED_ONE_BYTE_STRING(isolate, "_read"));
-  CHECK(cb->IsFunction());
-
-  Local<Object> retFlags = Object::New(isolate);
-
-  Local<Object> buffer =
-      Buffer::New(env, reinterpret_cast<char*>(buf), length,
-                  &FreeCallbackNonop, nullptr).ToLocalChecked();
-  Local<Value> argv[] {
-    buffer,
-    retFlags
-  };
-
-  v8::MaybeLocal<Value> ret = cb.As<Function>()->Call(env->context(),
-                                             stream->object(),
-                                             arraysize(argv),
-                                             argv);
-  CHECK(!ret.IsEmpty());
-  int32_t val = ret.ToLocalChecked()->Int32Value();
-
-  // TODO(jasnell): There's likely a better, more elegant way of doing this.
-  if (retFlags->Get(FLAG_ENDSTREAM)->BooleanValue())
-    *flags |= NGHTTP2_FLAG_END_STREAM;
-  if (retFlags->Get(FLAG_ENDDATA)->BooleanValue())
-    *flags |= NGHTTP2_DATA_FLAG_EOF;
-  if (retFlags->Get(FLAG_NOENDSTREAM)->BooleanValue())
-    *flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
-
-  return val;
-}
-
-// Http2Header statics
-
+// Create a new Http2Headers object. The first argument is the
+// number of headers expected in order to reserve the space.
 void Http2Headers::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   new Http2Headers(env, args.This(), args[0]->IntegerValue());
@@ -375,25 +319,105 @@ void Http2Headers::GetSize(Local<String> property,
 
 // Http2Stream Statics
 
-// The Http2Stream class wraps an individual nghttp2_stream struct.
 Http2Stream::Http2Stream(Environment* env,
                          Local<Object> wrap,
                          Http2Session* session,
                          int32_t stream_id) :
                          AsyncWrap(env, wrap, AsyncWrap::PROVIDER_HTTP2STREAM),
+                         StreamBase(env),
                          session_(session),
                          stream_id_(stream_id) {
   Wrap(object(), this);
-  prev_ = nullptr;
-  next_ = nullptr;
-  stream_ = nghttp2_session_find_stream(**session, stream_id);
+  str_in_ = NodeBIO::New();
+  str_out_ = NodeBIO::New();
+  NodeBIO::FromBIO(str_in_)->AssignEnvironment(env);
+  NodeBIO::FromBIO(str_out_)->AssignEnvironment(env);
+  provider_.read_callback = Http2Stream::on_read;
+  provider_.source.ptr = this;
+  set_alloc_cb({ OnAllocSelf, this });
+  set_read_cb({ OnReadSelf, this });
+  nghttp2_session_set_stream_user_data(**session, stream_id, this);
 }
 
-// TODO(jasnell): Implement these. The Add Stream and Remove Stream methods
-// are used as part of the HTTP/2 stream prioritization grouping.
-void Http2Stream::RemoveStream(Http2Stream* stream) {}
-void Http2Stream::AddStream(Http2Stream* stream, Http2Session* session) {}
+nghttp2_stream* Http2Stream::operator*() {
+  return nghttp2_session_find_stream(**session(), id());
+}
 
+void Http2Stream::Detach() {
+  if (!detached_) {
+    CHECK_NE(session_, nullptr);
+    detached_ = true;
+    nghttp2_session_set_stream_user_data(**session_, stream_id_, nullptr);
+    provider_.read_callback = nullptr;
+    provider_.source.ptr = nullptr;
+    session_ = nullptr;
+    // Emit Detached Event on the Http2Stream object to notify
+    // the JS side that the underlying nghttp2_stream handle
+    // is no longer valid.
+    Local<Value> argv[] { env()->detached_string() };
+    Emit(argv, arraysize(argv));
+  }
+}
+
+void Http2Stream::Dispose(const FunctionCallbackInfo<Value>& args) {
+  Http2Stream* stream;
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  ClearWrap(stream->object());
+  stream->persistent().Reset();
+  delete stream;
+}
+
+// Called when chunks of data from a DATA frame are received for this stream.
+// This will only be called if the Http2Stream is still attached to the session.
+void Http2Stream::ReceiveData(const uint8_t* data, size_t len) {
+  CHECK_NE(str_in_, nullptr);
+  NodeBIO::FromBIO(str_in_)->Write(
+      reinterpret_cast<const char*>(data),
+      len);
+  EmitPendingData();
+}
+
+void Http2Stream::OnAllocSelf(size_t suggested_size, uv_buf_t* buf, void* ctx) {
+  buf->base = node::Malloc(suggested_size);
+  buf->len = suggested_size;
+}
+
+void Http2Stream::OnReadSelf(ssize_t nread,
+                             const uv_buf_t* buf,
+                             uv_handle_type pending,
+                             void* ctx) {
+  Http2Stream* wrap = static_cast<Http2Stream*>(ctx);
+  Local<Object> buf_obj;
+  if (buf != nullptr)
+    buf_obj = Buffer::New(wrap->env(), buf->base, buf->len).ToLocalChecked();
+  wrap->EmitData(nread, buf_obj, Local<Object>());
+}
+
+void Http2Stream::EmitPendingData() {
+  if (!reading_) return;
+  // Rules, emit if there is any data pending in str_in_
+  NodeBIO* in = NodeBIO::FromBIO(str_in_);
+  while (in->Length() > 0) {
+    size_t avail = 0;
+    char* data = in->Peek(&avail);
+    uv_buf_t buf;
+    OnAlloc(avail, &buf);
+    if (buf.len < avail)
+      avail = buf.len;
+    memcpy(buf.base, data, avail);
+    OnRead(avail, &buf);
+    in->Read(nullptr, avail);
+  }
+
+  // If str_in_ is empty and stream is remote closed, emit EOF
+  if (nghttp2_session_get_stream_remote_close(**session(), id()) != 0) {
+    OnRead(UV_EOF, nullptr);
+  }
+  // If str_in_ is empty and stream is not remote closed, do nothing
+}
+
+// Returns the AsyncWrap uid for the Http2Stream instance. This is
+// provided primarily for debugging and logging purposes.
 void Http2Stream::GetUid(Local<String> property,
                          const PropertyCallbackInfo<Value>& args) {
   Http2Stream* stream;
@@ -402,15 +426,17 @@ void Http2Stream::GetUid(Local<String> property,
   args.GetReturnValue().Set(Number::New(env->isolate(), stream->get_uid()));
 }
 
+// Returns the Http2Session associated with this Http2Stream. Returns
+// Undefined if the Http2Stream instance is detached.
 void Http2Stream::GetSession(Local<String> property,
                              const PropertyCallbackInfo<Value>& info) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  Environment* env = stream->env();
-  HandleScope scope(env->isolate());
+  if (stream->detached_) return;
   info.GetReturnValue().Set(stream->session()->object());
 }
 
+// Returns the HTTP/2 Stream ID as a signed 32-bit integer
 void Http2Stream::GetID(Local<String> property,
                         const PropertyCallbackInfo<Value>& args) {
   Http2Stream* stream;
@@ -418,102 +444,137 @@ void Http2Stream::GetID(Local<String> property,
   args.GetReturnValue().Set(stream->id());
 }
 
+// Returns the current state of the HTTP/2 Stream as provided
+// by nghttp2. If the Http2Stream is detached, the state is
+// reported as NGHTTP2_STREAM_STATE_CLOSED
 void Http2Stream::GetState(Local<String> property,
                            const PropertyCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  args.GetReturnValue().Set(nghttp2_stream_get_state(**stream));
+  nghttp2_stream_proto_state state =
+      stream->detached_ ? NGHTTP2_STREAM_STATE_CLOSED :
+                          nghttp2_stream_get_state(**stream);
+  args.GetReturnValue().Set(state);
 }
 
+// Returns the nghttp2 managed summed dependency weight of this
+// Http2Stream instance. If the Http2Stream instance is detached,
+// then a value of 0 is returned.
 void Http2Stream::GetSumDependencyWeight(
     Local<String> property,
     const PropertyCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  args.GetReturnValue().Set(nghttp2_stream_get_sum_dependency_weight(**stream));
+  args.GetReturnValue().Set(
+      stream->detached_ ? 0 :
+          nghttp2_stream_get_sum_dependency_weight(**stream));
 }
 
+// Returns the nghttp2 managed priority weight of this Http2Stream
+// instance. If the Http2Stream instance is detached, then a value
+// of 0 is returned.
 void Http2Stream::GetWeight(Local<String> property,
                             const PropertyCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  args.GetReturnValue().Set(nghttp2_stream_get_weight(**stream));
+  args.GetReturnValue().Set(
+      stream->detached_ ? 0 : nghttp2_stream_get_weight(**stream));
 }
 
+// Return the Local Window Size for this Http2Stream instance.
+// If the Http2Stream instance is detached, a value of 0 is returned
 void Http2Stream::GetLocalWindowSize(Local<String> property,
                                      const PropertyCallbackInfo<Value>& info) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
-  info.GetReturnValue().Set(
-      nghttp2_session_get_stream_local_window_size(**session, stream->id()));
+  if (stream->detached_) {
+    info.GetReturnValue().Set(0);
+  } else {
+    Http2Session* session = stream->session();
+    CHECK(**session);
+    info.GetReturnValue().Set(
+        nghttp2_session_get_stream_local_window_size(**session, stream->id()));
+  }
 }
 
+// Modify the Local Window Size of this Http2Stream. This may
+// result in a WINDOW_UPDATE frame being sent to the peer. If
+// the Http2Stream instance is detached, this is a non-op
 void Http2Stream::SetLocalWindowSize(Local<String> property,
                                      Local<Value> value,
                                      const PropertyCallbackInfo<void>& info) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
+  if (stream->detached_) return;
   Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
+  CHECK(**session);
   nghttp2_session_set_local_window_size(
       **session, NGHTTP2_FLAG_NONE, stream->id(), value->Int32Value());
 }
 
+// Returns 1 if the local peer half closed the stream, returns
+// 0 if it did not, and -1 if the stream ID is unknown or if
+// the Http2Stream instance is detached.
 void Http2Stream::GetStreamLocalClose(
     Local<String> property,
     const PropertyCallbackInfo<Value>& info) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
-  info.GetReturnValue().Set(
-      nghttp2_session_get_stream_local_close(**session, stream->id()));
+  if (stream->detached_) {
+    info.GetReturnValue().Set(-1);
+  } else {
+    Http2Session* session = stream->session();
+    CHECK(**session);
+    info.GetReturnValue().Set(
+        nghttp2_session_get_stream_local_close(**session, stream->id()));
+  }
 }
 
+// Returns 1 if the remote peer half closed the stream, returns
+// 0 if it did not, and -1 if the stream ID is unknown or if
+// the Http2Stream instance is detached.
 void Http2Stream::GetStreamRemoteClose(
     Local<String> property,
     const PropertyCallbackInfo<Value>& info) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
-  info.GetReturnValue().Set(
-      nghttp2_session_get_stream_remote_close(**session, stream->id()));
+  if (stream->detached_) {
+    info.GetReturnValue().Set(-1);
+  } else {
+    Http2Session* session = stream->session();
+    CHECK(**session);
+    info.GetReturnValue().Set(
+        nghttp2_session_get_stream_remote_close(**session, stream->id()));
+  }
 }
 
-
-void Http2Stream::SendTrailers(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
-  Http2Headers* headers;
-  THROW_AND_RETURN_UNLESS_HTTP2HEADERS(env, args[0]);
-  ASSIGN_OR_RETURN_UNWRAP(&headers, args[0].As<Object>());
-  int rv = nghttp2_submit_trailer(**session, stream->id(),
-                                  **headers, headers->Size());
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+void Http2Stream::Resume() {
+  if (detached_) return;
+  nghttp2_session_resume_data(**session_, id());
+  session_->SendIfNecessary();
 }
 
+// Tells nghttp2 to resume sending DATA frames for this stream. This
+// is a non-op if the Http2Stream instance is detached.
 void Http2Stream::ResumeData(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
-  if (stream->IsLocalOpen())
-    nghttp2_session_resume_data(**session, stream->id());
-  nghttp2_session_send(**session);
+  stream->Resume();
 }
 
+// Send a 100-Continue response. In HTTP/2, a 100-continue is implemented
+// by sending a HEADERS frame on the stream before the primary response
+// HEADERS frame. These are distinguished on the client by the use of the
+// 100 status code. If this Http2Stream instance is detached, then this
+// is a non-op.
+// TODO(jasnell): Currently, this does not permit any additional headers
+// to be sent along with the 100 status.
 void Http2Stream::SendContinue(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  if (stream->detached_) return;
   Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
+  CHECK(**session);
   nghttp2_nv headers[] {{
     const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(HTTP2_HEADER_STATUS)),
     const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>("100")),
@@ -521,117 +582,243 @@ void Http2Stream::SendContinue(const FunctionCallbackInfo<Value>& args) {
   }};
   int rv = nghttp2_submit_headers(**session, NGHTTP2_FLAG_NONE, stream->id(),
                                   nullptr, &headers[0], 1, nullptr);
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  session->EmitErrorIfFail(rv);
 }
 
+// Initiate sending a response. Response Headers must have been set
+// before calling. This will result in sending an initial HEADERS
+// frame (or multiple), zero or more DATA frames, and zero or more
+// trailing HEADERS frames. If this Http2Stream instance is detached
+// then this is a non-op
 void Http2Stream::Respond(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  if (stream->detached_) return;
   Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
-  nghttp2_data_provider* provider = nullptr;
-  Http2Headers* headers;
-  THROW_AND_RETURN_UNLESS_HTTP2HEADERS(env, args[0]);
-  ASSIGN_OR_RETURN_UNWRAP(&headers, args[0].As<Object>());
-  if (args.Length() > 1) {
-    if (!args[1]->IsObject())
-      return env->ThrowTypeError(
-        "Second argument must be an Http2DataProvider object");
-    Http2DataProvider* dataProvider;
-    THROW_AND_RETURN_UNLESS_HTTP2DATAPROVIDER(env, args[1]);
-    ASSIGN_OR_RETURN_UNWRAP(&dataProvider, args[1].As<Object>());
-    provider = **dataProvider;
-  }
-  int rv = nghttp2_submit_response(**session, stream->id(), **headers,
-                                   headers->Size(), provider);
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  CHECK(**session);
+  bool nodata = args[0]->BooleanValue();
+  nghttp2_data_provider* provider = nodata ? nullptr : stream->provider();
+  int rv = nghttp2_submit_response(**session,
+                                   stream->id(),
+                                   stream->OutgoingHeaders(),
+                                   stream->OutgoingHeadersCount(),
+                                   provider);
+  session->EmitErrorIfFail(rv);
 }
 
-void Http2Stream::SendDataFrame(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
-
-  uint8_t flags = 0;
-  if (args[0]->BooleanValue())
-    flags |= NGHTTP2_FLAG_END_STREAM;
-
-  if (!args[1]->IsObject())
-    return env->ThrowTypeError(
-      "Second argument must be an Http2DataProvider object");
-  Http2DataProvider* provider;
-  THROW_AND_RETURN_UNLESS_HTTP2DATAPROVIDER(env, args[1]);
-  ASSIGN_OR_RETURN_UNWRAP(&provider, args[1].As<Object>());
-
-  int rv = nghttp2_submit_data(**session, flags, stream->id(), **provider);
-  EMIT_ERROR_IF_FAIL(env, session, rv);
-}
-
+// Send an RST-STREAM frame for this stream. The first argument is
+// an unsigned int32 that identifies the RST-STREAM error code. If
+// this Http2Stream instance is detached then this is a non-op
 void Http2Stream::SendRstStream(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  if (stream->detached_) return;
   Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
+  CHECK(**session);
   int rv = nghttp2_submit_rst_stream(**session, NGHTTP2_FLAG_NONE,
                                      stream->id(), args[0]->Uint32Value());
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  session->EmitErrorIfFail(rv);
 }
 
+// Send a PRIORITY frame for this stream. There are three arguments:
+//   parent (int32) the ID of the parent stream
+//   priority (int32) the priority value to assign
+//   exclusive (bool) true to set the exclusive flag
+// If this Http2Stream instance is detached, then this is a non-op
 void Http2Stream::SendPriority(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  if (stream->detached_) return;
   Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
+  CHECK(**session);
   Http2Priority priority(args[0]->Int32Value(),
                          args[1]->Int32Value(),
                          args[2]->BooleanValue());
   int rv = nghttp2_submit_priority(**session, NGHTTP2_FLAG_NONE,
                                    stream->id(), *priority);
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  session->EmitErrorIfFail(rv);
 }
 
+// Change the stream priority without sending a PRIORITY frame. There
+// are three arguments:
+//   parent (int32) the ID of the parent stream
+//   priority (int32) the priority value to assign
+//   exclusive (bool) true to set the exclusive flag
+// If this Http2Stream instance is detached, then this is a non-op
 void Http2Stream::ChangeStreamPriority(
     const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  if (stream->detached_) return;
   Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
+  CHECK(**session);
   Http2Priority priority(args[0]->Int32Value(),
                          args[1]->Int32Value(),
                          args[2]->BooleanValue());
   int rv = nghttp2_session_change_stream_priority(**session, stream->id(),
                                                   *priority);
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  session->EmitErrorIfFail(rv);
 }
 
+// Send a PUSH_PROMISE frame, then create and return the Http2Stream
+// instance that is associated. The first argument is an Http2Headers
+// object instance used to pass along the PUSH_PROMISE headers. If
+// this Http2Stream instance is detached, then this is a non-op
 void Http2Stream::SendPushPromise(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   HandleScope scope(env->isolate());
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  if (stream->detached_) return;
   Http2Session* session = stream->session();
-  SESSION_OR_RETURN(session);
-  if (nghttp2_session_check_server_session(**session) == 0) {
+  CHECK(**session);
+  if (!session->IsServer()) {
     return env->ThrowError("Client Http2Session instances cannot use push");
   }
   Http2Headers* headers;
   THROW_AND_RETURN_UNLESS_HTTP2HEADERS(env, args[0]);
   ASSIGN_OR_RETURN_UNWRAP(&headers, args[0].As<Object>());
-  int32_t ret =
+  int32_t rv =
       nghttp2_submit_push_promise(**session,
                                   NGHTTP2_FLAG_NONE,
                                   stream->id(),
                                   **headers, headers->Size(),
                                   stream);
-  EMIT_ERROR_IF_FAIL(env, session, ret);
+  session->EmitErrorIfFail(rv);
   args.GetReturnValue().Set(
-      Http2Session::create_stream(env, session, ret)->object());
+      Http2Session::CreateStream(env, session, rv)->object());
+}
+
+// Called when end() has been called on the Writable side of the Http2Stream
+// Duplex. Sets the internal writable state to false and resumes sending
+// any additional data pending so long as the Http2Stream is not detached.
+int Http2Stream::DoShutdown(ShutdownWrap* req_wrap) {
+  writable_ = false;
+  if (!detached_) Resume();
+  req_wrap->Dispatched();
+  req_wrap->Done(0);
+  return 0;
+}
+
+// Called when data has been written on the Writable side of the Http2Stream
+// Duplex. Causes the data to be buffered on the internal NodeBIO str_out_
+// buffer. The data is only buffered if the Http2Stream instance is not
+// detached.
+int Http2Stream::DoWrite(WriteWrap* w,
+                         uv_buf_t* bufs,
+                         size_t count,
+                         uv_stream_t* send_handle) {
+  // Buffer the data for the Data Provider
+  CHECK_EQ(send_handle, nullptr);
+
+  // Simply write to the outgoing buffer. The buffer will be
+  // written out when the data provider callback is invoked.
+  // If the Http2Stream instance has been detached, then it
+  // does not do any good to keep storing the data.
+  // TODO(jasnell): Later could likely make this a CHECK
+  if (!detached_) {
+    for (size_t i = 0; i < count; i++) {
+      // Only attempt to write if the buf is not empty
+      if (bufs[i].len > 0)
+        NodeBIO::FromBIO(str_out_)->Write(bufs[i].base, bufs[i].len);
+    }
+  }
+  // Whether detached or not, call dispatch and done.
+  w->Dispatched();
+  w->Done(0);
+  return 0;
+}
+
+bool Http2Stream::IsAlive() {
+  return !detached_ &&
+         nghttp2_stream_get_state(**this) != NGHTTP2_STREAM_STATE_CLOSED;
+}
+
+bool Http2Stream::IsClosing() {
+  return detached_;
+}
+
+// Upon calling ReadStart, the Http2Stream instance will immediately
+// emit all of the data currently stored in it's internal buffer and
+// will set the reading_ flag to true. While the reading_ flag is set,
+// all writes into the internal buffer will trigger the EmitPendingData
+// function, allowing data events to be emitted.
+int Http2Stream::ReadStart() {
+  reading_ = true;
+  EmitPendingData();
+  return 0;
+}
+
+// ReadStop flips the reading_ bit back to false, stopping the EmitPendingData
+// method from completing when called.
+int Http2Stream::ReadStop() {
+  reading_ = false;
+  return 0;
+}
+
+// on_read is called by nghttp2 to poll for bytes for outbound
+// DATA frames. Please see the code comments for on_read in
+// node_http2.h for more detail
+ssize_t Http2Stream::on_read(nghttp2_session* session,
+                             int32_t stream_id,
+                             uint8_t* buf,
+                             size_t length,
+                             uint32_t* flags,
+                             nghttp2_data_source* source,
+                             void* user_data) {
+  Http2Stream* stream = static_cast<Http2Stream*>(source->ptr);
+  CHECK(!stream->detached_);
+
+  NodeBIO* bio = NodeBIO::FromBIO(stream->str_out_);
+
+  ssize_t amount = bio->Read(reinterpret_cast<char*>(buf), length);
+
+  if (amount == 0 && stream->writable_) {
+    return NGHTTP2_ERR_DEFERRED;
+  }
+  if (!stream->writable_ && bio->Length() == 0) {
+    *flags |= NGHTTP2_DATA_FLAG_EOF;
+    if (stream->OutgoingTrailersCount() > 0) {
+      // If there are any trailing headers they have to be
+      // queued up to send here.
+      *flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+        nghttp2_submit_trailer(session,
+                                stream->id(),
+                                stream->OutgoingTrailers(),
+                                stream->OutgoingTrailersCount());
+    }
+  }
+  return amount;
+}
+
+// Adds an outgoing header. These must be set before the Http2Stream::Respond
+// method is called. Any headers added after that call will not be sent.
+void Http2Stream::AddHeader(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Http2Stream* stream;
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  Utf8Value key(env->isolate(), args[0]);
+  Utf8Value value(env->isolate(), args[1]);
+  bool noindex = args[2]->BooleanValue();
+  stream->AddHeader(*key, *value, key.length(), value.length(), noindex);
+}
+
+// Adds an outgoing trailer. These must be set before the writable side
+// of the Http2Stream Duplex is end()'ed. Any headers added after that
+// call will not be sent. Specifically, the trailers vector is processed
+// immediately after reading the final block of data has been submitted
+// to nghttp2 for inclusion in the DATA frames. The specific timing is
+// somewhat non-deterministic as it depends largely on when nghttp2
+// is able to process the outgoing frame queue. The rule is: any trailers
+// added after calling end *likely* will not be sent.
+void Http2Stream::AddTrailer(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Http2Stream* stream;
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  Utf8Value key(env->isolate(), args[0]);
+  Utf8Value value(env->isolate(), args[1]);
+  bool noindex = args[2]->BooleanValue();
+  stream->AddTrailer(*key, *value, key.length(), value.length(), noindex);
 }
 
 // Http2Session Statics
@@ -645,31 +832,34 @@ Http2Session::Http2Session(Environment* env,
                            AsyncWrap(env, wrap,
                                      AsyncWrap::PROVIDER_HTTP2SESSION),
                            type_(type) {
-  Wrap(object(), this);
+  MakeWeak<Http2Session>(this);
   nghttp2_session_callbacks* cb;
   nghttp2_session_callbacks_new(&cb);
+
+#define SET_SESSION_CALLBACK(callbacks, name)                                 \
+  nghttp2_session_callbacks_set_##name##_callback(callbacks, name);
+
   SET_SESSION_CALLBACK(cb, send)
   SET_SESSION_CALLBACK(cb, on_frame_recv)
   SET_SESSION_CALLBACK(cb, on_stream_close)
   SET_SESSION_CALLBACK(cb, on_header)
   SET_SESSION_CALLBACK(cb, on_begin_headers)
   SET_SESSION_CALLBACK(cb, on_data_chunk_recv)
-  SET_SESSION_CALLBACK(cb, on_frame_send)
   SET_SESSION_CALLBACK(cb, select_padding);
+
+#undef SET_SESSION_CALLBACK
+
   Http2Options opts(env, options);
-  switch (type) {
-    case SESSION_TYPE_CLIENT:
-      nghttp2_session_client_new2(&session_, cb, this, *opts);
-      break;
-    case SESSION_TYPE_SERVER:
-      // Fallthrough
-    default:
-      nghttp2_session_server_new2(&session_, cb, this, *opts);
-      break;
+  if (type == SESSION_TYPE_CLIENT) {
+    nghttp2_session_client_new2(&session_, cb, this, *opts);
+  } else {
+    nghttp2_session_server_new2(&session_, cb, this, *opts);
   }
   nghttp2_session_callbacks_del(cb);
-  root_ = create_stream(env, this, 0);
 
+  // When the Http2Session instance is created, it takes
+  // over consumption of the underlying stream in order
+  // to optimize reads and writes.
   if (!external.IsEmpty() && external->IsExternal()) {
     Consume(external);
   }
@@ -677,6 +867,8 @@ Http2Session::Http2Session(Environment* env,
 
 static const size_t kAllocBufferSize = 64 * 1024;
 
+// Used to allocate buffer space when reading from the
+// underlying stream.
 void Http2Session::OnAllocImpl(size_t suggested_size,
                                uv_buf_t* buf,
                                void* ctx) {
@@ -690,7 +882,7 @@ void Http2Session::OnAllocImpl(size_t suggested_size,
   buf->len = kAllocBufferSize;
 }
 
-
+// Used when reading data from the underlying stream
 void Http2Session::OnReadImpl(ssize_t nread,
                               const uv_buf_t* buf,
                               uv_handle_type pending,
@@ -707,20 +899,29 @@ void Http2Session::OnReadImpl(ssize_t nread,
                               session->prev_read_cb_.ctx);
     return;
   }
+
+  // Pass the read data on to nghttp2 for processing
   nghttp2_session_mem_recv(**session,
                            reinterpret_cast<const uint8_t*>(buf->base),
                            nread);
-  if (nghttp2_session_want_write(**session))
-    nghttp2_session_send(**session);
+  // Send any pending frame that exist in nghttp2 queue
+  session->SendIfNecessary();
 }
 
+// Release the captured stream. Currently this is done
+// only when the Http2Stream is deconstructed.
 void Http2Session::Unconsume() {
   if (prev_alloc_cb_.is_empty())
     return;
+  stream_->set_alloc_cb(prev_alloc_cb_);
+  stream_->set_read_cb(prev_read_cb_);
   prev_alloc_cb_.clear();
   prev_read_cb_.clear();
+  stream_ = nullptr;
 }
 
+// Capture the stream that will this session will use to send and
+// receive data
 void Http2Session::Consume(Local<Value> external) {
   Local<External> stream_obj = external.As<External>();
   StreamBase* stream = static_cast<StreamBase*>(stream_obj->Value());
@@ -728,6 +929,7 @@ void Http2Session::Consume(Local<Value> external) {
 
   stream->Consume();
 
+  stream_ = stream;
   prev_alloc_cb_ = stream->alloc_cb();
   prev_read_cb_ = stream->read_cb();
 
@@ -735,6 +937,8 @@ void Http2Session::Consume(Local<Value> external) {
   stream->set_read_cb({ Http2Session::OnReadImpl, this });
 }
 
+// Gets the AsyncWrap uid of the Http2Session object. This is provided
+// primarily for debugging purposes.
 void Http2Session::GetUid(Local<String> property,
                           const PropertyCallbackInfo<Value>& args) {
   Http2Session* session;
@@ -743,29 +947,49 @@ void Http2Session::GetUid(Local<String> property,
   args.GetReturnValue().Set(Number::New(env->isolate(), session->get_uid()));
 }
 
-// The send callback is invoked by the nghttp library when there is outgoing
-// data to be sent to a connected peer. The user_data is a pointer to the
-// Http2Session wrapper.
+// Called by nghttp2 when there is data to send on this session.
+// This is generally trigged by calling the Http2Session::SendIfNecessary
+// method but there are other APIs that will trigger it also. The data
+// buffer passed in contains the serialized frame data to be sent to
+// the stream.
 ssize_t Http2Session::send(nghttp2_session* session,
                            const uint8_t* data,
                            size_t length,
                            int flags,
                            void *user_data) {
-  Http2Session* session_obj =
-    static_cast<Http2Session*>(user_data);
+  Http2Session* session_obj = static_cast<Http2Session*>(user_data);
+  CHECK_NE(session_obj, nullptr);
   Environment* env = session_obj->env();
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
 
-  // Copy the data because we don't own it and cannot be sure
-  // exactly when it will be released by the nghttp2 library.
-  Local<Object> buffer =
-      Buffer::Copy(env, reinterpret_cast<const char*>(data),
-                   length).ToLocalChecked();
-  EMIT(env, session_obj, "send", buffer);
+  Local<Object> req_wrap_obj =
+      env->write_wrap_constructor_function()
+          ->NewInstance(env->context()).ToLocalChecked();
+
+  auto cb = [](WriteWrap* req, int status) {};
+  WriteWrap* write_req = WriteWrap::New(env,
+                                        req_wrap_obj,
+                                        nullptr,
+                                        cb);
+
+  uv_buf_t buf[] {
+    uv_buf_init(
+        const_cast<char*>(reinterpret_cast<const char*>(data)),
+        length)
+  };
+  int err = session_obj->stream_->DoWrite(write_req, buf, 1, nullptr);
+
+  if (err) {
+    // Ignore Errors
+    write_req->Dispose();
+  }
   return length;
 }
 
+// Called whenever an RST_STREAM frame has been received. Results
+// in the emission of an rststream event. The event is emitted
+// with two arguments: the numeric stream ID and the numeric
+// error code. By the time this is emitted, the underlying
+// stream object will have already been detached.
 int Http2Session::on_rst_stream_frame(Http2Session* session,
                                       int32_t id,
                                       const nghttp2_frame_hd hd,
@@ -773,13 +997,24 @@ int Http2Session::on_rst_stream_frame(Http2Session* session,
   Environment* env = session->env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
-  EMIT(env, session, "rst-stream",
-       Integer::New(env->isolate(), id),
-       Integer::NewFromUnsigned(env->isolate(), rst.error_code));
+
+  Local<Value> argv[] {
+    env->rststream_string(),
+    Integer::New(env->isolate(), id),
+    Integer::NewFromUnsigned(env->isolate(), rst.error_code)
+  };
+  session->Emit(argv, arraysize(argv));
+
   return 0;
 }
 
-
+// Called whenever a GOAWAY frame has been received. Results
+// in the emission of a goaway event. The event is emitted
+// with three arguments: the numeric error code, the ID of
+// the last processed stream ID as reported by the peer, and
+// a Buffer containing any additiona opaque data included in
+// the goaway. If there is no opaque data, the third argument
+// will be passed as Undefined.
 int Http2Session::on_goaway_frame(Http2Session* session,
                                   const nghttp2_frame_hd hd,
                                   const nghttp2_goaway goaway) {
@@ -797,54 +1032,40 @@ int Http2Session::on_goaway_frame(Http2Session* session,
     opaque_data = Undefined(isolate);
   }
 
-  EMIT(env, session, "goaway",
-       Integer::NewFromUnsigned(isolate, goaway.error_code),
-       Integer::New(isolate, goaway.last_stream_id),
-       opaque_data);
+  Local<Value> argv[] {
+    env->goaway_string(),
+    Integer::NewFromUnsigned(isolate, goaway.error_code),
+    Integer::New(isolate, goaway.last_stream_id),
+    opaque_data
+  };
+  session->Emit(argv, arraysize(argv));
 
   return 0;
 }
 
-
-int Http2Session::on_data_frame(Http2Session* session,
-                                Http2Stream* stream,
-                                const nghttp2_frame_hd hd,
-                                const nghttp2_data data) {
-  Environment* env = session->env();
-  Isolate* isolate = env->isolate();
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
-  EMIT(env, session, "data",
-       stream->object(),
-       Integer::NewFromUnsigned(isolate, hd.flags),
-       Integer::New(isolate, hd.length),
-       Integer::New(isolate, data.padlen));
-  return 0;
-}
-
+// Called by nghttp2 while processing a chunk of data from a received
+// DATA frame. The data is written to the Http2Stream's internal buffer
 int Http2Session::on_data_chunk_recv(nghttp2_session* session,
                                      uint8_t flags,
                                      int32_t stream_id,
                                      const uint8_t* data,
                                      size_t len,
                                      void* user_data) {
-  Http2Session* session_obj =
-    static_cast<Http2Session*>(user_data);
-  Environment* env = session_obj->env();
-  Isolate* isolate = env->isolate();
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
-  const char* cdata = reinterpret_cast<const char*>(data);
-  Http2Stream* stream =
-      static_cast<Http2Stream*>(
-        nghttp2_session_get_stream_user_data(session, stream_id));
-  EMIT(env, session_obj, "data-chunk",
-       stream->object(),
-       Integer::NewFromUnsigned(isolate, flags),
-       Buffer::Copy(env, cdata, len).ToLocalChecked());
+  Http2Stream* stream = Http2Stream::GetFromSession(session, stream_id);
+  CHECK_NE(stream, nullptr);
+  stream->ReceiveData(data, len);
   return 0;
 }
 
+// Called whenever a HEADERS frame is received. Results in the
+// emission of a headers event. The event is emitted with four
+// arguments: the associated Http2Stream, the numeric flags
+// bit field, the ES6 Map object containing the received headers,
+// and a numeric headers type category as provided by nghttp2.
+// The category argument indicates whether or not this HEADERS
+// frame represents the start of a request, response, push_promise,
+// or trailers block. nghttp2 makes the appropriate determination
+// based on the current state of the underlying nghttp2_stream.
 int Http2Session::on_headers_frame(Http2Session* session,
                                    Http2Stream* stream,
                                    const nghttp2_frame_hd hd,
@@ -852,23 +1073,29 @@ int Http2Session::on_headers_frame(Http2Session* session,
   Environment* env = session->env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
-  EMIT(env, session, "headers",
-       stream->object(),
-       Integer::NewFromUnsigned(env->isolate(), hd.flags),
-       stream->GetHeaders(),
-       Integer::NewFromUnsigned(env->isolate(), stream->GetHeadersCategory()));
+
+  Local<Value> argv[] {
+    env->headers_string(),
+    stream->object(),
+    Integer::NewFromUnsigned(env->isolate(), hd.flags),
+    stream->GetHeaders(),
+    Integer::NewFromUnsigned(env->isolate(), stream->GetHeadersCategory())
+  };
+  session->Emit(argv, arraysize(argv));
+
   stream->ClearHeaders();
   return 0;
 }
 
 // Called when nghttp2 receives a frame from the connected peer.
+// nghttp2 will automatically handle several connection specific
+// frames such as PRIORITY, PING and WINDOW_UPDATE.
 int Http2Session::on_frame_recv(nghttp2_session *session,
                                 const nghttp2_frame *frame,
                                 void *user_data) {
-  Http2Session* session_obj =
-    static_cast<Http2Session*>(user_data);
-  Http2Stream* stream_data;
-  // TODO(jasnell): This needs to handle the other frame types
+  Http2Session* session_obj = static_cast<Http2Session*>(user_data);
+  CHECK_NE(session_obj, nullptr);
+  Http2Stream* stream;
   switch (frame->hd.type) {
   case NGHTTP2_RST_STREAM:
     return on_rst_stream_frame(session_obj,
@@ -877,50 +1104,45 @@ int Http2Session::on_frame_recv(nghttp2_session *session,
                                frame->rst_stream);
   case NGHTTP2_GOAWAY:
     return on_goaway_frame(session_obj, frame->hd, frame->goaway);
-  case NGHTTP2_DATA:
-    stream_data =
-        static_cast<Http2Stream*>(
-            nghttp2_session_get_stream_user_data(session, frame->hd.stream_id));
-    return on_data_frame(session_obj, stream_data, frame->hd, frame->data);
   case NGHTTP2_HEADERS:
-    stream_data =
-      static_cast<Http2Stream*>(
-          nghttp2_session_get_stream_user_data(session, frame->hd.stream_id));
-    return on_headers_frame(session_obj, stream_data,
-                            frame->hd, frame->headers);
+    stream = Http2Stream::GetFromSession(session, frame->hd.stream_id);
+    CHECK_NE(stream, nullptr);
+    return on_headers_frame(session_obj, stream, frame->hd, frame->headers);
   default:
     return 0;
   }
 }
 
-
+// Called by nghttp2 when an underlying nghttp2_stream handle has been
+// closed and is no longer valid. We use this to clean up our Http2Stream
+// object's associated state.
 int Http2Session::on_stream_close(nghttp2_session *session,
                                   int32_t stream_id,
                                   uint32_t error_code,
                                   void *user_data) {
-  Http2Session* session_obj =
-    static_cast<Http2Session*>(user_data);
+  Http2Session* session_obj = static_cast<Http2Session*>(user_data);
+  CHECK_NE(session_obj, nullptr);
   Environment* env = session_obj->env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
-  Http2Stream* stream =
-      static_cast<Http2Stream*>(
-        nghttp2_session_get_stream_user_data(session, stream_id));
-  nghttp2_session_set_stream_user_data(session, stream_id, nullptr);
-  if (!stream)
-    return 0;
-  EMIT(env, session_obj, "stream-close",
-       stream->object(),
-       Integer::NewFromUnsigned(env->isolate(), error_code));
+  Http2Stream* stream = Http2Stream::GetFromSession(session, stream_id);
+  CHECK_NE(stream, nullptr);
+  stream->Detach();
 
-  ClearWrap(stream->object());
-  stream->persistent().Reset();
-  delete stream;
+  // TODO(jasnell): Collapse this into the detach event. Perhaps use
+  // "close" instead of "detach" as the event name
+  Local<Value> argv[] {
+    env->streamclose_string(),
+    stream->object(),
+    Integer::NewFromUnsigned(env->isolate(), error_code)
+  };
+  session_obj->Emit(argv, arraysize(argv));
 
   return 0;
 }
 
 // Called when an individual header name+value pair is processed by nghttp2.
+// The name and value are simply collected by the Http2Stream instance.
 int Http2Session::on_header(nghttp2_session *session,
                             const nghttp2_frame *frame,
                             const uint8_t *name,
@@ -930,74 +1152,61 @@ int Http2Session::on_header(nghttp2_session *session,
                             uint8_t flags,
                             void *user_data) {
   Http2Stream* stream =
-      static_cast<Http2Stream*>(
-        nghttp2_session_get_stream_user_data(session, frame->hd.stream_id));
-  CHECK(stream != nullptr);
+      Http2Stream::GetFromSession(session, frame->hd.stream_id);
+  CHECK_NE(stream, nullptr);
   stream->SetHeader(name, namelen, value, valuelen);
   return 0;
 }
 
-
+// Called by nghttp2 when beginning to process a block of headers.
+// We use the callback here to initialize a new block of header storage
+// in the Http2Stream. At any given time, the Http2Stream can process
+// only one block of headers at a time.
 int Http2Session::on_begin_headers(nghttp2_session* session,
                                    const nghttp2_frame* frame,
                                    void* user_data) {
-  Http2Session* session_obj =
-    static_cast<Http2Session*>(user_data);
+  Http2Session* session_obj = static_cast<Http2Session*>(user_data);
+  CHECK_NE(session_obj, nullptr);
   Environment* env = session_obj->env();
   Http2Stream* stream =
-      static_cast<Http2Stream*>(
-        nghttp2_session_get_stream_user_data(session, frame->hd.stream_id));
-  if (stream == nullptr) {
-    stream = create_stream(env, session_obj, frame->hd.stream_id);
-  }
-  CHECK(stream != nullptr);
+      Http2Stream::GetFromSession(session, frame->hd.stream_id);
+  if (stream == nullptr)
+    stream = CreateStream(env, session_obj, frame->hd.stream_id);
+  CHECK_NE(stream, nullptr);
   stream->SetHeaders(frame->headers.cat);
   return 0;
 }
 
-
-// Called when nghttp2 sends a frame to the connected peer
-int Http2Session::on_frame_send(nghttp2_session* session,
-                                const nghttp2_frame* frame,
-                                void* user_data) {
-  Http2Session* session_obj =
-    static_cast<Http2Session*>(user_data);
-  Environment* env = session_obj->env();
-  Isolate* isolate = env->isolate();
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
-  EMIT(env, session_obj, "frame-sent",
-       Integer::NewFromUnsigned(isolate, frame->hd.stream_id),
-       Integer::NewFromUnsigned(isolate, frame->hd.type),
-       Integer::NewFromUnsigned(isolate, frame->hd.flags));
-  return 0;
-}
-
+// Called by nghttp2 to determine the amount of padding to use
+// for a given frame.
 ssize_t Http2Session::select_padding(nghttp2_session *session,
                                      const nghttp2_frame *frame,
                                      size_t max_payloadlen,
                                      void *user_data) {
   // TODO(jasnell): Determine algorithm for seleting padding
+  // Returning any value > frame->hd.length will intrduce
+  // padding into the frame.
   return frame->hd.length;
 }
 
-Http2Stream* Http2Session::create_stream(Environment* env,
-                                         Http2Session* session,
-                                         uint32_t stream_id) {
+// Creates and returns a new Http2Stream instance that wraps an
+// nghttp2_stream.
+Http2Stream* Http2Session::CreateStream(Environment* env,
+                                        Http2Session* session,
+                                        uint32_t stream_id) {
   HandleScope scope(env->isolate());
   CHECK_EQ(env->http2stream_constructor_template().IsEmpty(), false);
   Local<Function> constructor =
       env->http2stream_constructor_template()->GetFunction();
   CHECK_EQ(constructor.IsEmpty(), false);
-  Local<Object> obj =
-      constructor->NewInstance(env->context()).ToLocalChecked();
-  Http2Stream* stream = new Http2Stream(env, obj, session, stream_id);
-  if (stream_id > 0)
-    Http2Stream::AddStream(stream, session);
-  nghttp2_session_set_stream_user_data(**session, stream_id, stream);
-  return stream;
+  Local<Object> obj = constructor->NewInstance(env->context()).ToLocalChecked();
+  return new Http2Stream(env, obj, session, stream_id);
 }
 
+// Create a new Http2Session instance. The first argument is the numeric
+// indicator of the type of session to create (see enum http2_session_type).
+// The second argument is the options object. The third argument is the
+// stream to capture.
 void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   if (!args.IsConstructCall())
@@ -1011,7 +1220,7 @@ void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
   new Http2Session(env, args.This(), type, args[1], args[2]);
 }
 
-
+// Returns true if this Http2Session is expecting to receive data
 void Http2Session::GetWantRead(Local<String> property,
                                const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
@@ -1019,6 +1228,7 @@ void Http2Session::GetWantRead(Local<String> property,
   info.GetReturnValue().Set(nghttp2_session_want_read(**session) != 0);
 }
 
+// Returns true if this Http2Stream has data queued up to send
 void Http2Session::GetWantWrite(Local<String> property,
                                 const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
@@ -1026,14 +1236,7 @@ void Http2Session::GetWantWrite(Local<String> property,
   info.GetReturnValue().Set(nghttp2_session_want_write(**session) != 0);
 }
 
-void Http2Session::GetRootStream(Local<String> property,
-                                 const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(session->root_->object());
-}
-
-
+// Returns the Http2Session type identifier.
 void Http2Session::GetType(Local<String> property,
                            const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
@@ -1047,7 +1250,6 @@ void Http2Session::GetEffectiveLocalWindowSize(
     const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   info.GetReturnValue().Set(
       nghttp2_session_get_effective_local_window_size(**session));
 }
@@ -1058,7 +1260,6 @@ void Http2Session::GetEffectiveRecvDataLength(
     const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   info.GetReturnValue().Set(
       nghttp2_session_get_effective_recv_data_length(**session));
 }
@@ -1068,7 +1269,6 @@ void Http2Session::GetNextStreamID(Local<String> property,
                                    const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   info.GetReturnValue().Set(nghttp2_session_get_next_stream_id(**session));
 }
 
@@ -1078,7 +1278,6 @@ void Http2Session::SetNextStreamID(Local<String> property,
                                    const PropertyCallbackInfo<void>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   int32_t id = value->Int32Value();
   nghttp2_session_set_next_stream_id(**session, id);
 }
@@ -1088,7 +1287,6 @@ void Http2Session::GetLocalWindowSize(Local<String> property,
                                    const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   info.GetReturnValue().Set(nghttp2_session_get_local_window_size(**session));
 }
 
@@ -1097,7 +1295,6 @@ void Http2Session::SetLocalWindowSize(Local<String> property,
                                       const PropertyCallbackInfo<void>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   nghttp2_session_set_local_window_size(
       **session, NGHTTP2_FLAG_NONE, 0, value->Int32Value());
 }
@@ -1107,7 +1304,6 @@ void Http2Session::GetLastProcStreamID(
     const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   info.GetReturnValue().Set(nghttp2_session_get_last_proc_stream_id(**session));
 }
 
@@ -1117,7 +1313,6 @@ void Http2Session::GetRemoteWindowSize(
     const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   info.GetReturnValue().Set(nghttp2_session_get_remote_window_size(**session));
 }
 
@@ -1127,7 +1322,6 @@ void Http2Session::GetOutboundQueueSize(
     const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   size_t size = nghttp2_session_get_outbound_queue_size(**session);
   Environment* env = session->env();
   info.GetReturnValue().Set(Integer::New(env->isolate(), size));
@@ -1139,7 +1333,6 @@ void Http2Session::GetDeflateDynamicTableSize(
     const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   size_t size = nghttp2_session_get_hd_deflate_dynamic_table_size(**session);
   Environment* env = session->env();
   info.GetReturnValue().Set(Integer::New(env->isolate(), size));
@@ -1151,7 +1344,6 @@ void Http2Session::GetInflateDynamicTableSize(
     const PropertyCallbackInfo<Value>& info) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  SESSION_OR_RETURN(session);
   size_t size = nghttp2_session_get_hd_inflate_dynamic_table_size(**session);
   Environment* env = session->env();
   info.GetReturnValue().Set(Integer::New(env->isolate(), size));
@@ -1163,14 +1355,12 @@ void Http2Session::GetLocalSettings(
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
   Environment* env = session->env();
-  SESSION_OR_RETURN(session);
   HandleScope scope(env->isolate());
   CHECK_EQ(env->http2settings_constructor_template().IsEmpty(), false);
   Local<Function> constructor =
       env->http2settings_constructor_template()->GetFunction();
   CHECK_EQ(constructor.IsEmpty(), false);
-  Local<Object> obj =
-      constructor->NewInstance(env->context()).ToLocalChecked();
+  Local<Object> obj = constructor->NewInstance(env->context()).ToLocalChecked();
   new Http2Settings(env, obj, session, true);
   info.GetReturnValue().Set(obj);
 }
@@ -1182,7 +1372,6 @@ void Http2Session::SetLocalSettings(
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
   Environment* env = session->env();
-  SESSION_OR_RETURN(session);
 
   Http2Settings* settings;
   THROW_AND_RETURN_UNLESS_HTTP2SETTINGS(env, value);
@@ -1192,7 +1381,7 @@ void Http2Session::SetLocalSettings(
 
   nghttp2_submit_settings(**session, NGHTTP2_FLAG_NONE,
                           &entries[0], entries.size());
-  nghttp2_session_send(**session);
+  session->SendIfNecessary();
 }
 
 void Http2Session::GetRemoteSettings(
@@ -1201,37 +1390,34 @@ void Http2Session::GetRemoteSettings(
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
   Environment* env = session->env();
-  SESSION_OR_RETURN(session);
 
   HandleScope scope(env->isolate());
   CHECK_EQ(env->http2settings_constructor_template().IsEmpty(), false);
   Local<Function> constructor =
       env->http2settings_constructor_template()->GetFunction();
   CHECK_EQ(constructor.IsEmpty(), false);
-  Local<Object> obj =
-      constructor->NewInstance(env->context()).ToLocalChecked();
+  Local<Object> obj = constructor->NewInstance(env->context()).ToLocalChecked();
   new Http2Settings(env, obj, session, false);
   info.GetReturnValue().Set(obj);
 }
 
-
+// Releases state but does not completely tear everything down. Currently
+// this is mainly used to release the consumption of the underlying stream
+// once the socket has been destroyed. This will effectively make the
+// session a non-op. Because the Ht2Session constructor calls MakeWeak,
+// the ~Http2Session destructor wil called to clean up the rest when
+// the object eventually gets garbage collected.
 void Http2Session::Destroy(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  SESSION_OR_RETURN(session);
-  EMIT0(session->env(), session, "destroy");
   session->Unconsume();
-  ClearWrap(session->object());
-  session->persistent().Reset();
-  delete session;
 }
 
-
+// Signals termination of the nghttp2_session by sending a GOAWAY
+// frame. The only argument is the goaway error code.
 void Http2Session::Terminate(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  SESSION_OR_RETURN(session);
 
   uint32_t error_code = args[0]->Uint32Value();
   uint32_t last_proc = nghttp2_session_get_last_proc_stream_id(**session);
@@ -1239,97 +1425,33 @@ void Http2Session::Terminate(const FunctionCallbackInfo<Value>& args) {
   int rv = last_proc > 0 ?
     nghttp2_session_terminate_session2(**session, last_proc, error_code) :
     nghttp2_session_terminate_session(**session, error_code);
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  session->EmitErrorIfFail(rv);
 
-  rv = nghttp2_session_send(**session);
-
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  rv = session->SendIfNecessary();
+  session->EmitErrorIfFail(rv);
 }
 
+// Signals initiation of a graceful termination process. Calling this
+// method by itself is not sufficient as this only sends a frame that
+// gives a pre-termination-warning to the peer. A subsequent call to
+// Terminate must be called either in nextTick or setImmediate to
+// complete the termination (ideally it would be in exactly one RTT)
 void Http2Session::GracefulTerminate(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   Http2Session* session;
   ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  SESSION_OR_RETURN(session);
 
   int rv = nghttp2_submit_shutdown_notice(**session);
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  session->EmitErrorIfFail(rv);
 
-  rv = nghttp2_session_send(**session);
-
-  EMIT_ERROR_IF_FAIL(env, session, rv);
+  rv = session->SendIfNecessary();
+  session->EmitErrorIfFail(rv);
 }
-
-/**
- * Arguments
- *  stream {integer}
- *  parent (integer)
- *  weight {integer}
- *  exclusive {boolean}
- **/
-void Http2Session::CreateIdleStream(const FunctionCallbackInfo<Value>& args) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  SESSION_OR_RETURN(session);
-  Http2Priority priority(args[1]->Int32Value(),
-                         args[2]->Int32Value(),
-                         args[3]->BooleanValue());
-  int32_t id = args[0]->Int32Value();
-  args.GetReturnValue().Set(
-      nghttp2_session_create_idle_stream(**session, id, *priority));
-}
-
-void Http2Session::ReceiveData(const FunctionCallbackInfo<Value>& args) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  if (!**session)
-    return;
-
-  Environment* env = Environment::GetCurrent(args);
-  THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
-  SPREAD_BUFFER_ARG(args[0], ts_obj);
-
-  uint8_t* data = reinterpret_cast<uint8_t*>(ts_obj_data);
-  ssize_t readlen = nghttp2_session_mem_recv(**session, data, ts_obj_length);
-  args.GetReturnValue().Set(Integer::NewFromUnsigned(env->isolate(), readlen));
-  if (!session->WantReadOrWrite())
-    EMIT0(env, session, "canClose");
-  nghttp2_session_send(**session);
-}
-
-
-void Http2Session::SendData(const FunctionCallbackInfo<Value>& args) {
-  Http2Session* session;
-  Environment* env = Environment::GetCurrent(args);
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  if (!**session)
-    return;
-  int rv = nghttp2_session_send(**session);
-  EMIT_ERROR_IF_FAIL(env, session, rv);
-  if (!session->WantReadOrWrite())
-    EMIT0(env, session, "canClose");
-}
-
-void Http2Session::GetStream(const FunctionCallbackInfo<Value>& args) {
-  Http2Session* session;
-  Environment* env = Environment::GetCurrent(args);
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  SESSION_OR_RETURN(session);
-  Http2Stream* stream =
-      static_cast<Http2Stream*>(
-          nghttp2_session_get_stream_user_data(**session,
-                                               args[0]->Int32Value()));
-  if (stream != nullptr) {
-    HandleScope scope(env->isolate());
-    args.GetReturnValue().Set(stream->object());
-  }
-}
-
 
 void HttpErrorString(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   args.GetReturnValue().Set(
-      OneByteString(env->isolate(), nghttp2_strerror(args[0]->Uint32Value())));
+      OneByteString(env->isolate(),
+                    nghttp2_strerror(args[0]->Uint32Value())));
 }
 
 
@@ -1344,8 +1466,6 @@ void Initialize(Local<Object> target,
   // Method to fetch the nghttp2 string description of an nghttp2 error code
   env->SetMethod(target, "nghttp2ErrorString", HttpErrorString);
 
-  Local<String> http2DataProviderClassName =
-     FIXED_ONE_BYTE_STRING(isolate, "Http2DataProvider");
   Local<String> http2HeadersClassName =
     FIXED_ONE_BYTE_STRING(isolate, "Http2Headers");
   Local<String> http2SessionClassName =
@@ -1356,10 +1476,10 @@ void Initialize(Local<Object> target,
     FIXED_ONE_BYTE_STRING(isolate, "Http2Settings");
 
   // Persistent FunctionTemplate for Http2Stream. Instances of this
-  // class are only intended to be created by Http2Session::create_stream
+  // class are only intended to be created by Http2Session::CreateStream
   // so the constructor is not exposed via the binding.
   Local<FunctionTemplate> stream_constructor_template =
-    Local<FunctionTemplate>(FunctionTemplate::New(isolate));
+     Local<FunctionTemplate>(FunctionTemplate::New(isolate));
   stream_constructor_template->SetClassName(http2StreamClassName);
   Local<ObjectTemplate> stream_template =
       stream_constructor_template->InstanceTemplate();
@@ -1440,12 +1560,6 @@ void Initialize(Local<Object> target,
                       "sendContinue",
                       Http2Stream::SendContinue);
   env->SetProtoMethod(stream_constructor_template,
-                      "sendTrailers",
-                      Http2Stream::SendTrailers);
-  env->SetProtoMethod(stream_constructor_template,
-                      "sendDataFrame",
-                      Http2Stream::SendDataFrame);
-  env->SetProtoMethod(stream_constructor_template,
                       "sendPriority",
                       Http2Stream::SendPriority);
   env->SetProtoMethod(stream_constructor_template,
@@ -1454,7 +1568,20 @@ void Initialize(Local<Object> target,
   env->SetProtoMethod(stream_constructor_template,
                       "sendPushPromise",
                       Http2Stream::SendPushPromise);
+  env->SetProtoMethod(stream_constructor_template,
+                      "addHeader",
+                      Http2Stream::AddHeader);
+  env->SetProtoMethod(stream_constructor_template,
+                      "addTrailer",
+                      Http2Stream::AddTrailer);
+  env->SetProtoMethod(stream_constructor_template,
+                      "destroy",
+                      Http2Stream::Dispose);
+  StreamBase::AddMethods<Http2Stream>(env, stream_constructor_template,
+                                      StreamBase::kFlagHasWritev);
+
   env->set_http2stream_constructor_template(stream_constructor_template);
+  target->Set(http2StreamClassName, stream_constructor_template->GetFunction());
 
   // Http2Settings Template
   Local<FunctionTemplate> settings =
@@ -1512,16 +1639,6 @@ void Initialize(Local<Object> target,
               http2SettingsClassName,
               settings->GetFunction()).FromJust();
 
-  // Http2DataProvider Template
-  Local<FunctionTemplate> provider =
-      env->NewFunctionTemplate(Http2DataProvider::New);
-  provider->InstanceTemplate()->SetInternalFieldCount(1);
-  provider->SetClassName(http2DataProviderClassName);
-  env->set_http2dataprovider_constructor_template(provider);
-  target->Set(context,
-              http2DataProviderClassName,
-              provider->GetFunction()).FromJust();
-
   // Http2Headers Template
   Local<FunctionTemplate> headers =
       env->NewFunctionTemplate(Http2Headers::New);
@@ -1565,13 +1682,6 @@ void Initialize(Local<Object> target,
   instance->SetAccessor(
       FIXED_ONE_BYTE_STRING(isolate, "wantRead"),
       Http2Session::GetWantRead,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "root"),
-      Http2Session::GetRootStream,
       nullptr,
       Local<Value>(),
       v8::DEFAULT,
@@ -1665,10 +1775,6 @@ void Initialize(Local<Object> target,
                       Http2Session::GracefulTerminate);
   env->SetProtoMethod(t, "destroy", Http2Session::Destroy);
   env->SetProtoMethod(t, "terminate", Http2Session::Terminate);
-  env->SetProtoMethod(t, "createIdleStream", Http2Session::CreateIdleStream);
-  env->SetProtoMethod(t, "sendData", Http2Session::SendData);
-  env->SetProtoMethod(t, "receiveData", Http2Session::ReceiveData);
-  env->SetProtoMethod(t, "getStream", Http2Session::GetStream);
 
 
   target->Set(context,


### PR DESCRIPTION
Updates, Round 5

@mcollina ... this update turns the internal Http2Stream object into a StreamBase. Below is a basic description of how it currently works:

1. When the Http2Session object is created, it takes over ownership and control of the Socket stream. As data is read off the socket, it is immediately passed into the Http2Session object for processing by the underlying nghttp2_session object.

2. When the nghttp2_session object detects that a new HTTP/2 Stream has been created, it emits a callback. I use that callback to create and store a new Http2Stream instance.

3. Among other things, the Http2Stream instance contains one inbound and one outbound data buffer provided by the NodeBIO class (see node_crypto_bio.h/node_crypto_bio.cc). The inbound buffer (str_in_) stores the data from DATA frames *received* from the socket and processed by nghttp2_session. The oubound buffer (str_out_) stores the data written by the application code that is pending to be sent to the peer. When the nghttp2_session instance is ready to read the outbound data, it repeatedly invokes a callback that pulls it out it fixed sized chunks.

4. As I mentioned, the Http2Stream object is an extension of StreamBase. The DoWrite method pushes user-written data into str_out_, where it is held until nghttp2_session is ready to process it.

5. When user code is ready to read data from the Http2Stream, the ReadStart method calls an EmitPendingData() method that iterates through _str_in and calls EmitData for each chunk of stored data. If there is no more data pending and the HTTP/2 Stream is in the CLOSED or HALF_CLOSED_REMOTE state, then an EOF is emitted signaling that there is no more data to be read.

6. At the JavaScript layer, Http2Stream extends Duplex and maps the relevant methods to the underlying StreamBase implementation.

7. At the HTTP API layer, there are two base objects Http2Incoming and Http2Outgoing and currently two server specific extensions Http2ServerRequest and Http2ServerResponse. Every Http2Stream has both an Http2Incoming and an Http2Outgoing instance, each of which should delegate to the Http2Stream's own Duplex interface.

8. Http2ServerRequest extends Http2Incoming. Http2Incoming extends Readable.

9. Http2ServerResponse extends Http2Outgoing. Http2Outgoing extends Writable.

10. When user code reads from Http2ServerRequest (e.g. `req.on('data', (chunk) => {})`), that needs to translate down into a read on the underlying Http2Stream readable interface. When user code writes to Http2ServerResponse (e.g. `res.write('<h1>hello!</h1>');`) that needs to translate down to a write on the underlying Http2Stream writable interface.

Some caveats:

The underlying HTTP/2 Stream can be closed at any time by the nghttp_session. There can be many reasons why this happens. When the HTTP/2 Stream is closed it is analogous to a socket closing in mid-write. We need to make sure stream closures are happening gracefully. The key thing to remember, however, an HTTP/2 Stream closing does not mean that the socket has closed (it may be, but Stream lifecycle is independent of session lifecycle).

The Http2Stream object wraps the nghttp2_stream reference. When nghttp2 closes the HTTP/2 stream, the nghttp2_stream object will no longer be usable/valid, but there will still be code using the Http2Stream object. I've only put partial and temporary measures in place that would ensure that the Http2Stream object can be safely and gracefully cleaned up in a situation where the nghttp2_stream has been closed while user code is still reading/writing from the Http2Stream StreamBase interface.

The way nghttp2 reads data to be sent in a response is as follows: after the Http2Stream instance has been created, the Respond method is used to initiate a response message flow. This calls the nghttp2_submit_response API. Passed into this API is the block of response headers to send along with a reference to an nghttp2_data_provider struct. This struct defines a callback that nghttp2 will call repeatedly to fetch the data that will be chunked into the individual DATA frames. These are generally fixed sized chunks whose size is determined by nghttp2 options (usually the default max frame size). If there is no data currently to be read and the user code has not yet signaled that it is done writing (end() has not been called yet), then the callback returns NGHTTP2_ERR_DEFERRED, putting the HTTP/2 Stream into a pending state. If there is no more pending data and the user code *has* finished writing, then the ENDDATA flag is set letting nghttp2 know that there is no more data to read. If we've reached the end of the data and there are trailing headers to be sent, the callback also schedules those for transmission. Once either (a) the trailing headers are sent or (b) if there are no trailers, the final DATA frame is sent, nghttp2 will signal the peer that the stream transmission is complete, putting the HTTP/2 stream into a Local-Half-Closed state (no further writes are possible). Note that nghttp2 will synchronously call this callback repeatedly until either NGHTTP2_ERR_DEFERRED is returned or until the ENDDATA flag has been set.

When an HTTP/2 Stream has been put into deferred state by returning NGHTTP2_ERR_DEFERRED in the data read callback, nghttp2 must be explicitly instructed to resume processing of that stream data. This is done using the nghttp2_stream_resume() API.

Various methods on Http2ServerResponse (especially those that write data to the str_out_ buffer inside Http2Stream) can initiate the response process. Examples include `end()`, `write()`, `writeHead()`, and `pipe()`. Because of the typical event flow, initiating the response will typically immediately result in the stream data being put into the deferred state. This is because the first call nghttp2 makes to the data read callback generally occurs before there is any data actually buffered into the std_out_ NodeBIO buffer. What this means is that whenever outbound data is written to the Http2Stream writable interface, nghttp2 must be explicitly told to resume processing of the stream so that the buffered data can be sent.

The performance of writing the data to the underlying session and ultimately out to the socket depends a significant deal on how quickly the data written to the std_out_ buffer can be read back out by the nghttp2 callback. This depends on a significant number of factors including the total number of streams concurrently being managed by the nghttp2_session that owns the HTTP/2 stream.

If the underlying HTTP/2 Stream closes completely, or if the HTTP/2 Stream enters the Local-Half-Closed state indicating that local writes are no longer permitted to the HTTP/2 Stream, then the writable side of the Http2Stream StreamBase/Duplex should be terminated. It is possible that there might still be data stored in the str_out_ NodeBIO buffer when this occurs. We'll need to make sure that (a) writes no longer happen after this state has been reached, (b) that the buffered data is cleaned up, and (c) that a proper "aborted" event is triggered at the HTTP API layer.

When a peer *sends* data to the nghttp2_session, nghttp2 will trigger a sequence of data chunk received callbacks that include the ID of the stream, a data buffer, and a length. Currently, these are written directly to the internal str_in_ NodeBIO buffer. The nghttp2 will take care of error handling that may occur if DATA frames are received at the wrong time during a streams lifecycle so fortunately we do not have to worry about that... and once the HTTP/2 Stream has been closed, nghttp2 will stop pushing data chunks into the str_in_ buffer.

The Readable side of the Http2Stream StreamBase/Duplex has to asynchronously pull chunks of data from the str_in_ buffer and emit those chunks. Ultimately, those need to be emitted via the Http2Incoming/Http2ServerRequest Readable interface. When the HTTP/2 Stream closes and the underlying nghttp2_stream reference becomes invalid, there still may be data buffered in the str_in_ NodeBIO buffer and there still may be active consumers. We need to decide how to handle this. It is entirely likely that an async consumer just simply has not yet had enough time to completely consume the data before the underlying HTTP/2 stream is closed.

Once nghttp2 detects that a peer has completed sending all of their data frames, the nghttp2_stream will be put into a Remote-Half-Closed state. This indicates that no more data will be received into the str_in_ buffer. When this happens, once all of the pending data has been read out of str_in_ via the Http2Stream Readable interface, EOF can be emitted and the readable side of the Http2Stream can end. This is different from a full close of the nghttp2_stream because the HTTP/2 Stream can still be *written* to.

The Http2Stream object holds onto a number of resources that must be freed explicitly when the Http2Stream object is no longer being used. When the underlying nghttp2_stream becomes invalid, then the cached nghttp2_stream and nghttp2_session pointers need to be cleared. When the Http2Stream is no longer being read from or written to, and we know that we are completely done interacting with the nghttp2_stream, then the Http2Stream object needs to be explicitly destroyed.

Another consideration: HTTP/2 allows both connection and stream level flow control. As a peer is sending data frames, it is not permitted to exceed the specific Flow Control Window for either the session or the individual stream. By setting a lower number, it is possible to throttle the amount of data a peer sends. By setting the value to 0, it is possible to temporarily halt the peers ability to send any data frames. When a session initially begins, there is a default frame window size and a peer is permitted to go ahead and send that amount of data if it chooses.

One strategy for limiting the amount of bytes we have to buffer in str_in_ from DATA frames received by a peer is to set the Flow Control Window to 0, effectively turning off the flow. However, it is possible and likely that the peer will send some amount of data before the Flow Control Window can be limited. Accordingly, we have to be prepared to maintain at least *some* amount of data in the str_in_ NodeBIO buffer. We can, however, set the Flow Control Window to 0 as the default when the session is created, then use the flow control APIs within the ReadStart and ReadStop methods to start and stop the flow of data. It's not a perfect control but it would help limit the bandwidth consumption on streams that are not actively being read from. I have not yet worked this into the implementation tho.

Let's see... what else... oh, push streams... When a push stream is initiated, a new Http2Stream instance is created. The key difference is that push Http2Stream instances are not *Readable*. The Readable side of the Http2Stream StreamBase/Duplex must be closed on start up. Only the *Writable* side will be active. That said, the push Http2Stream instance will still have both a Http2ServerRequest (Http2Incoming) and Http2ServerResponse (Http2Outgoing) associated with it. The Http2ServerRequest can only be used to access the pushed request headers. The writable Http2ServerResponse side of a push Http2Stream is otherwise exactly the same as a normal Http2Stream.

The following server code can be used to create a simple functioning HTTP/2 server based on this PR:

```js
const fs = require('fs');
const http2 = require('http').HTTP2;
const options = {
  key: fs.readFileSync('/Users/james/node/main/http2/test/fixtures/keys/agent2-key.pem'),
  cert: fs.readFileSync('/Users/james/node/main/http2/test/fixtures/keys/agent2-cert.pem')
};

function handler(req, res) {
  res.writeHead(200, {'content-type': 'text/html'});
  res.end('<html><head></head><body><h1>this is some data</h2></body></html>');
}

const server = http2.createSecureServer(options, handler);
server.setTimeout(10 * 1000);
server.listen(8000);
```

Here, the `req` object is the `Http2ServerRequest` and `res` is the `Http2ServerResponse`. Each of these have a `stream` property (e.g. `req.stream` and `res.stream` that return a reference to the `Http2Stream` instance. Each should return the same instance (`req.stream === res.stream`).

Also try variations on this that use async reads and writes to and from `res` and `req`, e.g.

```js
function handler(req, res) {
  res.writeHead(200, {'content-type': 'text/html'});
  setImmediate(() => {
    res.end('<html><head></head><body><h1>this is some data</h2></body></html>');
  });
}
```

```js
const fs = require('fs');
function handler(req, res) {
  res.writeHead(200, {'content-type': 'text/html'});
  fs.createReadStream('some-file').pipe(res);
}
```

The server should be accessible from Chrome and Firefox.

For testing, I also been using the nghttp command-line client to test:

Simple GET request:
```
$ nghttp -v  https://localhost:8000
```

PUT request that sends multiple DATA frames and includes padding:
```
$ nghttp -v -H':method: PUT' -b 100 -d src/node_http2.cc https://localhost:8000
```

The nghttp2 debug output can be switched on using `./configure --debug-nghttp2`

I've been using `node --inspect` to do other tracing and profiling to ensure no memory leaks, etc.

