### PR TITLE
Round6

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -346,6 +346,10 @@ TLSSocket.prototype.disableRenegotiation = function disableRenegotiation() {
   this[kDisableRenegotiation] = true;
 };
 
+TLSSocket.prototype.disableRenegotiation = function disableRenegotiation() {
+  this[kDisableRenegotiation] = true;
+};
+
 TLSSocket.prototype._wrapHandle = function(wrap) {
   var res;
   var handle;

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -342,6 +342,10 @@ TLSSocket.prototype.disableRenegotiation = function disableRenegotiation() {
   this[kDisableRenegotiation] = true;
 };
 
+TLSSocket.prototype.disableRenegotiation = function disableRenegotiation() {
+  this[kDisableRenegotiation] = true;
+};
+
 TLSSocket.prototype._wrapHandle = function(wrap) {
   var res;
   var handle;

--- a/lib/internal/http2.js
+++ b/lib/internal/http2.js
@@ -1,39 +1,98 @@
 'use strict';
 
+// General Notes:
+// * There are internal Http2Session and Http2Stream objects provided
+//   by process.binding('http2') and external Http2Session and Http2Stream
+//   classes exported here. The internal objects serve as the _handle for
+//   the external.
+//
+// * A FreeList pool is used to buffer and reuse instances of the internal
+//   Http2Session to reduce the need for creating new instances every time.
+//
+// * Both of the internal Http2Stream and Http2Session objects are AsyncWraps
+//
+// * The internal Http2Stream instance extends from StreamBase, it supports
+//   writev and does not expose the shutdown method. Within this StreamBase
+//   implementation, there are two in memory NodeBIO buffers, one for outbound
+//   data, the other for inbound.
+//
+// * The external Http2Stream class extends from Duplex. When data is written
+//   to the Writable side of the Duplex, the data is passed through via a
+//   StreamBase WriteReq to the underlying internal Http2Stream StreamBase
+//   implementation. From there, the data is written to the outgoing NodeBIO
+//   buffer where it is stored until nghttp2 is prompted to begin reading it
+//   out. When the internal Http2Stream StreamBase is told to begin Reading
+//   (when the readStart() method is called), chunks of data will be read
+//   out of the internal incoming NodeBIO buffer and pushed into the Readable
+//   side of the Http2Stream Duplex.
+//
+// * The Http2Incoming class is a Readable that wraps the external Http2Stream
+//   Duplex. When created, Http2Incoming redirects the data being read out of
+//   the internal incoming NodeBIO buffer to it's own Readable state as opposed
+//   to being pushed into the Http2Stream objects Readable state. The flow here
+//   likely is not ideal and needs to be optimized.
+//
+// * The Http2Outgoing class is a Writable that wraps the external Http2Stream
+//   Duplex. As data is written to the Http2Outgoing instance, it is forwarded
+//   on to Http2Stream Duplex writable interface which pushes it into the
+//   internal outgoing NodeBIO buffer instance. The flow here likely is not
+//   ideal and needs to be optimized
+//
+// * There are still a number of Readable/Writable state issues that need to be
+//   worked through.
+//
+// * Performance Bottlenecks: There are three fundamental performance
+//   bottlenecks at play in this implementation: (a) The Streams API, (b)
+//   How quickly we can pass data to and from the nghttp2 implementation
+//   (also related to the streams API via the Socket), and (c) How quickly
+//   and efficiently we can process the callbacks emitted by nghttp2 as
+//   it is processing the data.
+
 const http2 = process.binding('http2');
+const uv = process.binding('uv');
+const streamwrap = process.binding('stream_wrap');
 const timers = require('timers');
 const util = require('util');
 const Buffer = require('buffer').Buffer;
 const EventEmitter = require('events');
 const internalHttp = require('internal/http');
-const TLSServer = require('tls').Server;
-const NETServer = require('net').Server;
+const net = require('net');
+const tls = require('tls');
 const stream = require('stream');
-const WriteWrap = process.binding('stream_wrap').WriteWrap;
-const ShutdownWrap = process.binding('stream_wrap').ShutdownWrap;
-const uv = process.binding('uv');
+const FreeList = require('internal/freelist').FreeList;
+const url = require('url');
+const common = require('_http_common');
+const WriteWrap = streamwrap.WriteWrap;
 const Writable = stream.Writable;
 const Readable = stream.Readable;
 const Duplex = stream.Duplex;
+const TLSServer = tls.Server;
+const NETServer = net.Server;
 const constants = http2.constants;
 const utcDate = internalHttp.utcDate;
 
-const kStatusCode = Symbol('status-code');
-const kOptions = Symbol('options');
-const kStream = Symbol('stream');
+const kBeginSend = Symbol('begin-send');
+const kFinished = Symbol('finished');
+const kHandle = Symbol('handle');
 const kHeaders = Symbol('headers');
 const kHeadersSent = Symbol('headers-sent');
-const kSession = Symbol('session');
+const kId = Symbol('id');
+const kInFlight = Symbol('in-flight');
+const kOptions = Symbol('options');
+const kOwner = Symbol('owner');
+const kNoBody = Symbol('nobody');
 const kRequest = Symbol('request');
 const kResponse = Symbol('response');
-const kFinished = Symbol('finished');
-const kTrailers = Symbol('trailers');
 const kResume = Symbol('resume');
-const kBeginSend = Symbol('begin-send');
-const kInFlight = Symbol('in-flight');
 const kSendDate = Symbol('send-date');
-const kDetached = Symbol('detached');
-const kNoBody = Symbol('nobody')
+const kServer = Symbol('server');
+const kSession = Symbol('session');
+const kSocket = Symbol('socket');
+const kStatusCode = Symbol('status-code');
+const kStream = Symbol('stream');
+const kStreams = Symbol('streams');
+const kType = Symbol('type');
+const kTrailers = Symbol('trailers');
 
 const kDefaultSocketTimeout = 2 * 60 * 1000;
 const kRenegTest = /TLS session renegotiation disabled for this socket/;
@@ -44,57 +103,42 @@ Object.defineProperty(exports, 'constants', {
   value: constants
 });
 
-util.inherits(http2.Http2Session, EventEmitter);
-util.inherits(http2.Http2Stream, Duplex);
 
-function prepareStream(stream) {
-  Duplex.call(stream);
-  stream.on('detach', () => {
-    this[kDetached] = true;
-    stream.end();
-  });
+const sessions = new FreeList('session', 1000, initSessionHandle);
+
+function initSessionHandle() {
+  const session = new http2.Http2Session();
+  session.onRstStream = onRstStream;
+  session.onGoaway = onGoaway;
+  session.onHeaders = onHeaders;
+  session.onStreamClose = onStreamClose;
+  session.onError = onError;
+  return session;
 }
 
-// TODO(jasnell):
-// There are three key states that need to be tracked: (1) Is the Http2Stream
-// attached to the underlying Http2Session (e.g. that is, is the internal
-// nghttp2_stream handle still valid), (2) Is the Http2Stream Duplex interface
-// still Writable, and (3) Is the Http2Stream Duplex still Readable. The
-// Http2Stream object cannot be disposed of and garbage collected until all
-// three of those states are false. Because of async reads/writes on the Duplex
-// interface, it's possible for the Http2Stream to become detached from the
-// underlying Http2Session. Ideally, when that happens both the Readable and
-// Writable sides will close and any internally buffered data would be dropped
-// and additional writes will fail but I do not have that completely wired up
-// yet. The maybeDestroyStream(stream) check is largely a temporary stopgap to
-// determine when the Writable and Readable sides are closed so that we can
-// allow the Http2Stream to be garbage collected.
-function maybeDestroyStream(stream) {
-  // if ((!stream.readable &&
-  //      !stream.writable &&
-  //      !stream._writableState.length)) {
-  if ((!stream.writable &&
-       !stream._writableState.length)) {
-    timers.unenroll(stream);
-    stream.destroy();
+function freeSession(session) {
+  if (session) {
+    session.reset();
+    session[kOwner][kHandle] = undefined;
+    session[kOwner] = undefined;
+    if (sessions.free(session) === false)
+      session.close();
   }
 }
 
-// Called by the internal Http2Stream class when data has been read
-// and is being made available. This method is *not* part of the
-// public JS API of the Http2Stream object and should not be called
-// by anyone other than the internal HttpStream class. The defineProperty
-// call below intentionally makes the onread callback non-enumerable,
-// non-configurable and read-only in order to keep userland from altering
-// the expected behavior through monkey-patching.
-Object.defineProperty(http2.Http2Stream.prototype, 'onread', {
-  configurable: false,
-  enumerable: false,
-  value: onread
-});
-function onread(nread, buffer) {
-  const stream = this;
+function freeStream(stream) {
+  if (stream) {
+    stream.reset();
+    stream[kOwner].end();
+    stream[kOwner][kHandle] = undefined;
+    stream[kOwner] = undefined;
+    stream[kType] = undefined;
+    stream.close();
+  }
+}
 
+function onread(nread, buffer) {
+  const stream = this[kOwner];
   unrefTimer(this);
 
   if (nread > 0) {
@@ -128,76 +172,42 @@ function onread(nread, buffer) {
   }
 }
 
-http2.Http2Stream.prototype.refuse = function refuse() {
-  this.sendRstStream(constants.NGHTTP2_REFUSED_STREAM);
-};
-
-http2.Http2Stream.prototype.cancel = function cancel() {
-  this.sendRstStream(constants.NGHTTP2_CANCEL);
-};
-
-http2.Http2Stream.prototype.protocolError = function protocolError() {
-  this.sendRstStream(constants.NGHTTP2_PROTOCOL_ERROR);
-};
-
-// Individual Http2Stream instances can have their own activity timeouts
-// that operate in a manner that is identical to socket timeouts. The
-// key thing to remember with these is that for every set timeout there
-// is a Timer controlling it.
+function onRstStream(id, code) {
+  this[kOwner].emit('rststream', id, code);
+}
+function onGoaway(code, lastProcStreamID) {
+  this[kOwner].emit('goaway', code, lastProcStreamID);
+}
+function onHeaders(handle, flags, headers, category) {
+  var stream = handle[kOwner];
+  if (!stream) {
+    const id = handle.getId();
+    stream = new Http2Stream(this[kOwner], id, {});
+    stream._handle = handle;
+    this[kOwner][kStreams].set(id, stream);
+  }
+  this[kOwner].emit('headers', stream, flags, headers, category);
+}
+function onStreamClose(id, code) {
+  const stream = this[kOwner][kStreams].get(id);
+  if (stream) {
+    this[kOwner].emit('stream-close', stream, code);
+    this[kOwner][kStreams].delete(id);
+    freeStream(stream._handle);
+  }
+}
+function onError(error) {
+  this[kOwner].emit('error', error);
+}
 
 function unrefTimer(item) {
   timers._unrefActive(item);
 }
 
-http2.Http2Stream.prototype.setTimeout = function(msecs, callback) {
-  if (msecs === 0) {
-    timers.unenroll(this);
-    if (callback) {
-      this.removeListener('timeout', callback);
-    }
-  } else {
-    timers.enroll(this, msecs);
-    timers._unrefActive(this);
-    if (callback) {
-      this.once('timeout', callback);
-    }
-  }
-  return this;
-};
-
-function afterShutdown(status, handle, req) {
-  // After shutdown, wait a tick before possibly destroying the
-  // Http2Stream instance. This allows any pending writes to
-  // be dispatched.
-  process.nextTick(() => maybeDestroyStream(handle));
-}
-
-// End the Writable side of the Http2Stream Duplex.
-http2.Http2Stream.prototype.end = function(chunk, encoding, callback) {
-  // Unnecessary to end twice
-  const state = this._writableState;
-  if (state.ending || state.finished) {
-    return;
-  }
-
-  Duplex.prototype.end.call(this, chunk, encoding, callback);
-
-  // Once ended, let the internal Http2Class know that writing
-  // has ended. This allows proper termination of the sequence
-  // of DATA frames being fed into the underlying nghttp2_session
-  const req = new ShutdownWrap();
-  req.oncomplete = afterShutdown;
-  req.handle = this;
-  this.shutdown(req);
-};
-
-http2.Http2Stream.prototype._read = function(size) {
-  this.reading = true;
-  this.readStart();
-};
-
 function afterDoStreamWrite(status, handle, req) {
-  unrefTimer(handle);
+  unrefTimer(handle[kOwner]);
+  if (typeof req.callback === 'function')
+    req.callback();
 }
 
 function createWriteReq(req, handle, data, encoding) {
@@ -227,79 +237,343 @@ function createWriteReq(req, handle, data, encoding) {
   }
 }
 
-http2.Http2Stream.prototype._writev = function(chunks, cb) {
-  unrefTimer(stream);
-  const req = new WriteWrap();
-  req.handle = this;
-  req.oncomplete = afterDoStreamWrite;
-  req.async = false;
-  var err;
-
-  const data = new Array(chunks.length << 1);
-  for (var i = 0; i < chunks.length; i++) {
-    const entry = data[i];
-    data[i * 2] = entry.chunk;
-    data[i * 2 + 1] = entry.encoding;
+// TODO(jasnell):
+// There are three key states that need to be tracked: (1) Is the Http2Stream
+// attached to the underlying Http2Session (e.g. that is, is the internal
+// nghttp2_stream handle still valid), (2) Is the Http2Stream Duplex interface
+// still Writable, and (3) Is the Http2Stream Duplex still Readable. The
+// Http2Stream object cannot be disposed of and garbage collected until all
+// three of those states are false. Because of async reads/writes on the Duplex
+// interface, it's possible for the Http2Stream to become detached from the
+// underlying Http2Session. Ideally, when that happens both the Readable and
+// Writable sides will close and any internally buffered data would be dropped
+// and additional writes will fail but I do not have that completely wired up
+// yet. The maybeDestroyStream(stream) check is largely a temporary stopgap to
+// determine when the Writable and Readable sides are closed so that we can
+// allow the Http2Stream to be garbage collected.
+function maybeDestroyStream(stream) {
+  // if ((!stream.readable &&
+  //      !stream.writable &&
+  //      !stream._writableState.length)) {
+  if ((!stream.writable &&
+       !stream._writableState.length)) {
+    timers.unenroll(stream);
+    stream.session[kStreams].delete(stream.id);
+    freeStream(stream._handle);
   }
-  err = this.writev(req, data);
+}
 
-  // Retain chunks
-  if (err === 0) req._chunks = data;
 
-  if (err) {
-    throw util._errnoException(err, 'write', req.error);
-  }
-
-  this._bytesDispatched += req.bytes;
-
-  cb();
-};
-
-http2.Http2Stream.prototype._write = function(data, encoding, cb) {
-  unrefTimer(stream);
-  const req = new WriteWrap();
-  req.handle = this;
-  req.oncomplete = afterDoStreamWrite;
-  req.async = false;
-  var err;
-
-  var enc;
-  if (data instanceof Buffer) {
-    enc = 'buffer';
-  } else {
-    enc = encoding;
-  }
-  err = createWriteReq(req, this, data, enc);
-
-  if (err) {
-    throw util._errnoException(err, 'write', req.error);
+class Http2Stream extends Duplex {
+  constructor(session, id, options) {
+    super(options);
+    this[kId] = id;
+    this[kSession] = session;
   }
 
-  this._bytesDispatched += req.bytes;
-
-  cb();
-};
-
-// Begin graceful termination process. See:
-// https://nghttp2.org/documentation/nghttp2_submit_shutdown_notice.html
-// For detail. This process results in sending two GOAWAY frames to the
-// client. The second one is the actual GOAWAY that will terminate the
-// session. The second terminate and the passed in callback are invoked
-// on nextTick (TODO(jasnell): setImmediate might be better)).
-http2.Http2Session.prototype.gracefulTerminate = function(code, callback) {
-  if (typeof code === 'function') {
-    callback = code;
-    code = undefined;
+  get _handle() {
+    return this[kHandle];
   }
-  if (typeof callback !== 'function')
-    throw new TypeError('callback must be a function');
 
-  this.startGracefulTerminate();
-  process.nextTick(() => {
-    this.terminate(code || constants.NGHTTP2_NO_ERROR);
-    callback();
-  });
-};
+  set _handle(handle) {
+    if (!(handle instanceof http2.Http2Stream))
+      throw new TypeError('handle must be an Http2Stream');
+    this[kHandle] = handle;
+    this[kHandle].onread = onread;
+    this[kHandle][kOwner] = this;
+    this.emit('handle', handle);
+  }
+
+  get uid() {
+    if (this._handle)
+      return this._handle.getUid();
+  }
+
+  set id(id) {
+    this[kId] = Number(id);
+  }
+
+  get id() {
+    return this[kId];
+  }
+
+  get session() {
+    return this[kSession];
+  }
+
+  get state() {
+    const obj = {};
+    if (this._handle)
+      this._handle.getState(obj);
+    return obj;
+  }
+
+  setLocalWindowSize(size) {
+    if (this._handle) {
+      this._handle.setLocalWindowSize(size);
+    } else {
+      this.once('handle', () => {
+        this._handle.setLocalWindowSize(size);
+      });
+    }
+  }
+
+  changeStreamPriority(parentId, priority, exclusive) {
+    if (this._handle) {
+      this._handle.changeStreamPriority(parentId, priority, exclusive);
+    } else {
+      this.once('handle', () => {
+        this._handle.changeStreamPriority(parentId, priority, exclusive);
+      });
+    }
+  }
+
+  respond() {
+    if (this._handle) {
+      this._handle.respond();
+    } else {
+      this.once('handle', () => {
+        this._handle.respond();
+      });
+    }
+  }
+
+  resume() {
+    if (this._handle) {
+      this._handle.resume();
+    } else {
+      this.once('handle', () => {
+        this._handle.resume();
+      });
+    }
+  }
+
+  sendContinue() {
+    if (this._handle) {
+      this._handle.sendContinue();
+    } else {
+      this.once('handle', () => {
+        this._handle.sendContinue();
+      });
+    }
+  }
+
+  sendPriority(parentId, priority, exclusive) {
+    if (this._handle) {
+      this._handle.sendPriority(parentId, priority, exclusive);
+    } else {
+      this.once('handle', () => {
+        this._handle.sendPriority(parentId, priority, exclusive);
+      });
+    }
+  }
+
+  sendRstStream(code) {
+    if (this._handle) {
+      this._handle.sendRstStream(code);
+    } else {
+      this.once('handle', () => {
+        this._handle.sendRstStream(code);
+      });
+    }
+  }
+
+  sendPushPromise(headers) {
+    if (this._handle) {
+      return this._handle.sendPushPromise(mapToHeaders(headers));
+    } else {
+      this.once('handle', () => {
+        this._handle.sendPushPromise(mapToHeaders(headers));
+      });
+    }
+  }
+
+  addHeader(name, value, noindex) {
+    if (this._handle) {
+      this._handle.addHeader(name, value, noindex);
+    } else {
+      this.once('handle', () => {
+        this._handle.addHeader(name, value, noindex);
+      });
+    }
+  }
+
+  addTrailer(name, value, noindex) {
+    if (this._handle) {
+      this._handle.addTrailer(name, value, noindex);
+    } else {
+      this.once('handle', () => {
+        this._handle.addTrailer(name, value, noindex);
+      });
+    }
+  }
+
+  refuse() {
+    this.sendRstStream(constants.NGHTTP2_REFUSED_STREAM);
+  }
+
+  cancel() {
+    this.sendRstStream(constants.NGHTTP2_CANCEL);
+  }
+
+  protocolError() {
+    this.sendRstStream(constants.NGHTTP2_PROTOCOL_ERROR);
+  }
+
+  setTimeout(msecs, callback) {
+    if (msecs === 0) {
+      timers.unenroll(this);
+      if (callback) {
+        this.removeListener('timeout', callback);
+      }
+    } else {
+      timers.enroll(this, msecs);
+      timers._unrefActive(this);
+      if (callback) {
+        this.once('timeout', callback);
+      }
+    }
+    return this;
+  }
+
+  _write(data, encoding, cb) {
+    if (this._handle) {
+      unrefTimer(this);
+      const req = new WriteWrap();
+      req.handle = this._handle;
+      req.callback = cb;
+      req.oncomplete = afterDoStreamWrite;
+      req.async = false;
+      const enc = data instanceof Buffer ? 'buffer' : encoding;
+      const err = createWriteReq(req, this._handle, data, enc);
+      if (err)
+        throw util._errnoException(err, 'write', req.error);
+      this._bytesDispatched += req.bytes;
+    } else {
+      this.once('handle', () => {
+        this._write(data, encoding, cb);
+      });
+    }
+  }
+
+  end(chunk, encoding, callback) {
+    const state = this._writableState;
+    if (state.ending || state.finished) {
+      return;
+    }
+    super.end(chunk, encoding, callback);
+
+    if (this._handle) {
+      this._handle.finishedWriting();
+    } else {
+      this.on('handle', () => {
+        this._handle.finishedWriting();
+      });
+    }
+  }
+
+  _read(n) {
+    if (this._handle) {
+      this._handle.readStart();
+    } else {
+      this.once('handle', () => {
+        this._handle.readStart();
+      });
+    }
+  }
+}
+
+class Http2Session extends EventEmitter {
+  constructor(type, options, socket) {
+    super();
+    this[kType] = type;
+    this[kStreams] = new Map();
+    this[kHandle] = sessions.alloc();
+    this[kHandle][kOwner] = this;
+    this[kHandle].reinitialize(type, options, socket._handle._externalStream);
+  }
+
+  reset() {
+    if (this._handle)
+      this._handle.reset();
+  }
+
+  get _handle() {
+    return this[kHandle];
+  }
+
+  get uid() {
+    if (this._handle)
+      return this._handle.getUid();
+  }
+
+  get type() {
+    return this[kType];
+  }
+
+  get state() {
+    const obj = {};
+    if (this._handle)
+      this._handle.getState(obj);
+    return obj;
+  }
+
+  setNextStreamID(id) {
+    if (this._handle)
+      this._handle.setNextStreamID(id);
+  }
+
+  setLocalWindowSize(size) {
+    if (this._handle)
+      this._handle.setLocalWindowSize(size);
+  }
+
+  get remoteSettings() {
+    if (this._handle)
+      return this._handle.getRemoteSettings();
+  }
+
+  get localSettings() {
+    if (this._handle)
+      return this._handle.getLocalSettings();
+  }
+
+  set localSettings(settings) {
+    if (!(settings instanceof http2.Http2Settings))
+      throw new TypeError('settings must be an instance of Http2Settings');
+    if (this._handle) {
+      this._handle.setLocalSettings(settings);
+    }
+  }
+
+  // Begin graceful termination process. See:
+  // https://nghttp2.org/documentation/nghttp2_submit_shutdown_notice.html
+  // For detail. This process results in sending two GOAWAY frames to the
+  // client. The second one is the actual GOAWAY that will terminate the
+  // session. The second terminate and the passed in callback are invoked
+  // on nextTick (TODO(jasnell): setImmediate might be better)).
+  gracefulTerminate(code, callback) {
+    if (!this.isAlive) return;
+    if (typeof code === 'function') {
+      callback = code;
+      code = undefined;
+    }
+    if (typeof callback !== 'function')
+      throw new TypeError('callback must be a function');
+
+    this._handle.startGracefulTerminate();
+    process.nextTick(() => {
+      this._handle.terminate(code || constants.NGHTTP2_NO_ERROR);
+      callback();
+    });
+  }
+
+  request(headers, nobody) {
+    if (this._handle)
+      return this._handle.request(headers, nobody);
+  }
+}
+
 
 function initHttp2IncomingOptions(options) {
   // TODO(jasnell): It might make sense to set the default highWaterMark
@@ -315,18 +589,54 @@ function initHttp2OutgoingOptions(options) {
   return options;
 }
 
+function incomingOnRead(nread, buffer) {
+  const stream = this[kOwner][kRequest];
+  unrefTimer(this);
+
+  if (nread > 0) {
+    var ret = stream.push(buffer);
+    if (stream.reading && !ret) {
+      stream.reading = false;
+      var err = stream.readStop();
+      if (err) {
+        // TODO(jasnell): figure this out
+        maybeDestroyStream(stream);
+      }
+    }
+    return;
+  }
+
+  if (nread === 0) {
+    return;
+  }
+
+  if (nread !== uv.UV_EOF) {
+    // TODO(jasnell): figure out
+    return maybeDestroyStream(stream);
+  }
+
+  stream.push(null);
+
+  if (stream._readableState.length === 0) {
+    stream.readable = false;
+    // TODO(jasnell): Figure out
+    //maybeDestroy(self);
+  }
+}
+
 // Represents an incoming HTTP/2 message.
 // TODO(jasnell): This is currently incomplete
 class Http2Incoming extends Readable {
   constructor(stream, headers, options) {
     super(initHttp2IncomingOptions(options));
-    if (!(stream instanceof http2.Http2Stream))
+    if (!(stream instanceof Http2Stream))
       throw new TypeError('stream argument must be an Http2Stream instance');
     if (!(headers instanceof Map))
       throw new TypeError('headers argument must be a Map');
     this[kStream] = stream;
     this[kHeaders] = headers;
     this[kFinished] = false;
+    this[kStream]._handle.onread = incomingOnRead;
   }
 
   get finished() {
@@ -361,7 +671,7 @@ class Http2Incoming extends Readable {
   }
 
   _read(n) {
-    // TODO(@jasnell)
+    this[kStream]._handle.readStart();
   }
 }
 
@@ -511,7 +821,7 @@ class Http2Outgoing extends Writable {
 
   [kResume]() {
     if (this.stream) {
-      this.stream.resumeData();
+      this.stream.resume();
     }
   }
 }
@@ -655,14 +965,24 @@ class Http2PushResponse extends EventEmitter {
     if (typeof callback !== 'function')
       throw new TypeError('callback must be a function');
     const parent = this[kResponse].stream;
-    const ret = parent.sendPushPromise(mapToHeaders(this[kHeaders]));
+    const ret = parent.sendPushPromise(this[kHeaders]);
     if (ret) {
-      prepareStream(ret);
-      ret.readable = false;
-      ret[kRequest] = new Http2ServerRequest(ret, this[kHeaders]);
-      ret[kResponse] = new Http2ServerResponse(ret, ret[kResponse][kOptions]);
-      ret[kRequest][kFinished] = true;
-      callback(ret[kRequest], ret[kResponse]);
+      const id = ret.getId();
+      const stream = new Http2Stream(parent.session, id, {});
+      stream._handle = ret;
+      parent.session[kStreams].set(id, stream);
+
+      stream.readable = false;
+      const request =
+          stream[kRequest] =
+              new Http2ServerRequest(stream, this[kHeaders]);
+      const response =
+          stream[kResponse] =
+              new Http2ServerResponse(stream, this[kResponse][kOptions]);
+      request[kFinished] = true;
+      request[kInFlight] = true;
+      callback(request, response);
+      request[kInFlight] = false;
     }
   }
 }
@@ -797,129 +1117,117 @@ function socketOnTimeout(server, session) {
   return fn;
 }
 
-function socketOnceError(server) {
-  function fn(error) {
-    if (kRenegTest.test(error.message)) {
-      // A tls renegotiation attempt was made. There's no need
-      // to propogate the error and there's nothing more we can
-      // do with the connection. Destroy it and move on.
-      this.destroy();
-      return;
-    }
-    // If the socket experiences an error, there's not much that
-    // we're going to be able to do as the error could have a
-    // fatal impact on any number of open in-flight requests.
-    // In the http/1 implementation, we emit a clientError that
-    // gives the user code an opportunity to send a graceful
-    // HTTP error response. For here, since there may be any
-    // number of open streams, we'll notify the server of the
-    // failure allow it to do whatever it will. If no socketError
-    // listeners are registered, destroy the socket.
-    if (!server.emit('socketError', error, this)) {
-      this.destroy(error);
-    }
+function socketOnceError(error) {
+  if (kRenegTest.test(error.message)) {
+    // A tls renegotiation attempt was made. There's no need
+    // to propogate the error and there's nothing more we can
+    // do with the connection. Destroy it and move on.
+    this.destroy();
+    return;
   }
-  return fn;
+  // If the socket experiences an error, there's not much that
+  // we're going to be able to do as the error could have a
+  // fatal impact on any number of open in-flight requests.
+  // In the http/1 implementation, we emit a clientError that
+  // gives the user code an opportunity to send a graceful
+  // HTTP error response. For here, since there may be any
+  // number of open streams, we'll notify the server of the
+  // failure allow it to do whatever it will. If no socketError
+  // listeners are registered, destroy the socket.
+  if (!this[kServer].emit('socketError', error, this)) {
+    this.destroy(error);
+  }
 }
 
-function sessionOnHeaderComplete(server) {
-  function fn(stream, flags, headers, category) {
-    const finished = Boolean(flags & constants.NGHTTP2_FLAG_END_STREAM);
+function sessionOnHeaderComplete(stream, flags, headers, category) {
+  const finished = Boolean(flags & constants.NGHTTP2_FLAG_END_STREAM);
+  const server = this[kServer];
+  // This is a server, so the only header categories supported are
+  // NGHTTP2_HCAT_REQUEST and NGHGTTP2_HCAT_HEADERS. Other categories
+  // must result in a Protocol error per the spec.
+  var request;
+  var response;
+  switch (category) {
+    case constants.NGHTTP2_HCAT_REQUEST:
+      request = stream[kRequest] =
+          new Http2ServerRequest(stream, headers,
+                                 server[kOptions].defaultIncomingOptions);
+      response = stream[kResponse] =
+          new Http2ServerResponse(stream,
+                                  server[kOptions].defaultOutgoingOptions);
+      // finished will be true if the header block included flags to end
+      // the stream (such as when sending a GET request). In such cases,
+      // mark the kRequest stream finished so no data will be read.
+      if (finished)
+        request[kFinished] = true;
 
-    // This is a server, so the only header categories supported are
-    // NGHTTP2_HCAT_REQUEST and NGHGTTP2_HCAT_HEADERS. Other categories
-    // must result in a Protocol error per the spec.
-    var request;
-    var response;
-    switch (category) {
-      case constants.NGHTTP2_HCAT_REQUEST:
-        // This has to be a new stream, bootstrap it...
-        prepareStream(stream);
-
-        // header blocks in this category represent a new request.
-        request = stream[kRequest] =
-            new Http2ServerRequest(stream,
-                                   headers,
-                                   server[kOptions].defaultIncomingOptions);
-        response = stream[kResponse] =
-            new Http2ServerResponse(stream,
-                                   server[kOptions].defaultOutgoingOptions);
-        // finished will be true if the header block included flags to end
-        // the stream (such as when sending a GET request). In such cases,
-        // mark the kRequest stream finished so no data will be read.
-        if (finished) {
-          request[kFinished] = true;
-          request.end();
-        }
-        if (headers.has('expect')) {
-          // If there is an expect header that contains 100-continue,
-          // and the server has a listener for the checkContinue event,
-          // emit the checkContinue event instead of the request event.
-          // This behavior matches the current http/1 API.
-          if (/^100-continue$/i.test(headers.get('expect'))) {
-            if (server.listenerCount('checkContinue') > 0) {
-              request[kInFlight] = true;
-              server.emit('checkContinue', request, response);
-              request[kInFlight] = undefined;
-              break;
-            }
-            response.writeContinue();
-            // This falls through to the emit the request event
-          } else {
-            // If there is an expect header that contains anything
-            // other than 100-continue, emit the checkExpectation
-            // event if there are listeners or automatically return
-            // a 417 and end the response. This behavior matches the
-            // current http/1 API
-            if (server.listenerCount('checkExpectation') > 0) {
-              request[kInFlight] = true;
-              server.emit('checkExpectation', request, response);
-              request[kInFlight] = undefined;
-            } else {
-              response.writeHead(constants.HTTP_STATUS_EXPECTATION_FAILED);
-              response.end();
-            }
+      if (headers.has('expect')) {
+        // If there is an expect header that contains 100-continue,
+        // and the server has a listener for the checkContinue event,
+        // emit the checkContinue event instead of the request event.
+        // This behavior matches the current http/1 API.
+        if (/^100-continue$/i.test(headers.get('expect'))) {
+          if (server.listenerCount('checkContinue') > 0) {
+            request[kInFlight] = true;
+            server.emit('checkContinue', request, response);
+            request[kInFlight] = undefined;
             break;
           }
-        }
-        // Handle CONNECT requests. If there is a connect listener, emit the
-        // connect event rather than the request event, otherwise RST-STREAM
-        // with the NGHTTP2_REFUSED_STREAM code.
-        // TODO(jasnell): Still need to test that this is working correctly.
-        // To do so we need a client that can send a proper http/2 connect
-        // request.
-        if (request.method === 'CONNECT') {
-          if (server.listenerCount('connect') > 0) {
+          response.writeContinue();
+          // This falls through to the emit the request event
+        } else {
+          // If there is an expect header that contains anything
+          // other than 100-continue, emit the checkExpectation
+          // event if there are listeners or automatically return
+          // a 417 and end the response. This behavior matches the
+          // current http/1 API
+          if (server.listenerCount('checkExpectation') > 0) {
             request[kInFlight] = true;
-            server.emit('connect', request, response);
+            server.emit('checkExpectation', request, response);
             request[kInFlight] = undefined;
           } else {
-            stream.refuse();
+            response.writeHead(constants.HTTP_STATUS_EXPECTATION_FAILED);
+            response.end();
           }
           break;
         }
-        request[kInFlight] = true;
-        server.emit('request', request, response);
-        request[kInFlight] = undefined;
-        break;
-      case constants.NGHTTP2_HCAT_HEADERS:
-        if (!finished) {
-          // When category === NGHTTP2_HCAT_HEADERS and finished is not
-          // null, that means an extra HEADERS frame was sent after
-          // the initial HEADERS frame that opened the request, without the
-          // end stream flag set. Interstitial headers frames are not permitted
-          // in the HTTP semantic binding per the HTTP/2 spec
-          stream.protocolError();
-          return;
+      }
+      // Handle CONNECT requests. If there is a connect listener, emit the
+      // connect event rather than the request event, otherwise RST-STREAM
+      // with the NGHTTP2_REFUSED_STREAM code.
+      // TODO(jasnell): Still need to test that this is working correctly.
+      // To do so we need a client that can send a proper http/2 connect
+      // request.
+      if (request.method === 'CONNECT') {
+        if (server.listenerCount('connect') > 0) {
+          request[kInFlight] = true;
+          server.emit('connect', request, response);
+          request[kInFlight] = undefined;
+        } else {
+          stream.refuse();
         }
-        // If finished, that means these are trailing headers
-        stream[kRequest][kTrailers] = headers;
         break;
-      default:
+      }
+      request[kInFlight] = true;
+      server.emit('request', request, response);
+      request[kInFlight] = undefined;
+      break;
+    case constants.NGHTTP2_HCAT_HEADERS:
+      if (!finished) {
+        // When category === NGHTTP2_HCAT_HEADERS and finished is not
+        // null, that means an extra HEADERS frame was sent after
+        // the initial HEADERS frame that opened the request, without the
+        // end stream flag set. Interstitial headers frames are not permitted
+        // in the HTTP semantic binding per the HTTP/2 spec
         stream.protocolError();
-    }
+        return;
+      }
+      // If finished, that means these are trailing headers
+      stream[kRequest][kTrailers] = headers;
+      break;
+    default:
+      stream.protocolError();
   }
-  return fn;
 }
 
 function connectionListener(socket) {
@@ -927,6 +1235,8 @@ function connectionListener(socket) {
 
   // Create the Http2Session instance that is unique to this socket.
   const session = createServerSession(options, socket);
+  session[kServer] = this;
+  socket[kServer] = this;
 
   session.on('error', sessionOnError(this, socket));
 
@@ -946,15 +1256,17 @@ function connectionListener(socket) {
   socket.destroy = function(error) {
     session.removeAllListeners();
     socket.removeAllListeners();
-    session.destroy();
+    freeSession(session._handle);
     socket.destroy = destroySocket;
     destroySocket.call(socket, error);
+    socket[kServer] = undefined;
+    session[kServer] = undefined;
   };
-  socket.once('error', socketOnceError(this));
+  socket.once('error', socketOnceError);
   socket.on('resume', socketOnResume);
   socket.on('pause', socketOnPause);
   socket.on('drain', socketOnDrain);
-  session.on('headers', sessionOnHeaderComplete(this));
+  session.on('headers', sessionOnHeaderComplete);
   session.on('streamClose', sessionOnStreamClose);
   session.localSettings = options.settings;
 }
@@ -1024,19 +1336,11 @@ class Http2ServerSession extends NETServer {
 }
 
 function createServerSession(options, socket) {
-  const session =
-    new http2.Http2Session(constants.SESSION_TYPE_SERVER,
-                           options,
-                           socket._handle._externalStream);
-  EventEmitter.call(session);
-  return session;
+  return new Http2Session(constants.SESSION_TYPE_SERVER, options, socket);
 }
 
-function createClientSession(options) {
-  const session =
-    new http2.Http2Session(constants.SESSION_TYPE_CLIENT, options);
-  EventEmitter.call(session);
-  return session;
+function createClientSession(options, socket) {
+  return new Http2Session(constants.SESSION_TYPE_CLIENT, options, socket);
 }
 
 function createSecureServer(options, handler) {
@@ -1062,40 +1366,268 @@ function createServer(options, handler) {
 
 // Client Implementation
 
-class Http2ClientSession {
-  constructor(options, callback) {
-    this[kOptions] = initializeOptions(options);
-    this[kSession] = createClientSession(options);
+function acquireSocket(options, callback) {
+  switch (options.protocol) {
+    case 'http:':
+      return net.connect(options, callback);
+    case 'https:':
+      return tls.connect(options, callback);
+    default:
+      throw new Error(`Protocol ${options.protocol} not supported.`);
   }
 }
 
+function clientSessionOnError(client, socket) {
+  function fn(error) {
+    if (client.listenerCount('sessionError') > 0) {
+      client.emit('sessionError', error);
+      return;
+    }
+    socket.destroy(error);
+  }
+  return fn;
+}
 
-// There are several differences between this and _http_agent. Namely,
-// sockets are always assumed to be long lived and always have an associated
-// Http2Session.
-// class Http2Agent extends EventEmitter {
-//   constructor(options) {
-//     super();
-//     this[kSockets] = new WeakMap();
-//     this.on('free', (socket, options) => {});
-//   }
-// }
+function clientSessionOnHeaderComplete(stream, flags, headers, category) {
+  const finished = Boolean(flags & constants.NGHTTP2_FLAG_END_STREAM);
+  const request = stream[kRequest];
+  switch (category) {
+    case constants.NGHTTP2_HCAT_RESPONSE:
+      // TODO: Handle various types of responses appropriately
+      const response = new Http2ClientResponse(stream, headers, {});
+      stream[kResponse] = response;
+      request.emit('response', response);
+      break;
+    case constants.NGHTTP2_HCAT_HEADERS:
+      if (!finished) {
+        stream.protocolError();
+        return;
+      }
+      stream[kResponse][kTrailers] = headers;
+      break;
+    case constants.NGHTTP2_HCAT_PUSH_PROMISE:
+      // TODO(jasnell): Complete this
+      stream.cancel();
+      break;
+    default:
+      stream.protocolError();
+  }
+}
 
-// class Http2ClientRequest extends Http2Outgoing {
-//   constructor(stream, socket) {
-//     super(stream, socket);
-//   }
-// }
+function clientSessionOnStreamClose(stream, code) {
+  const request = stream[kRequest];
+  const response = stream[kResponse];
+  if (response && !response.finished) {
+    response.readable = false;
+    response[kFinished] = true;
+  }
+  if (request && !request.finished) {
+    request.end();
+    request[kFinished] = true;
+  }
 
-// class Http2ClientResponse extends Http2Incoming {
-//   constructor(stream, headers, socket) {
-//     super(stream, headers, socket);
-//   }
+  request[kStream] = undefined;
+  response[kStream] = undefined;
+  stream[kRequest] = undefined;
+  stream[kResponse] = undefined;
+  setImmediate(() => maybeDestroyStream(stream));
+}
 
-//   get status() {
-//     return this.headers.get(constants.HTTP2_HEADER_STATUS) | 0;
-//   }
-// }
+function initializeClientOptions(options) {
+  if (typeof options === 'string') {
+    //options = new URL(options);
+    options = url.parse(options);
+    if (!options.hostname)
+      throw new Error('Unable to determine the domain name');
+  } else {
+    options = util._extend({}, options);
+  }
+
+  var defaultPort = 80;
+  if (options.protocol === 'https:')
+    defaultPort = 443;
+  options.port = options.port || defaultPort || 80;
+
+  options.hostname = options.host = options.hostname || 'localhost';
+  options.method = (options.method || 'GET').toUpperCase();
+  if (!common._checkIsHttpToken(options.method)) {
+    throw new TypeError('Method must be a valid HTTP token');
+  }
+  options.path = options.path || '/';
+  return initializeOptions(options);
+}
+
+class Http2ClientSession extends EventEmitter {
+  constructor(options, callback) {
+    super();
+    this[kOptions] = initializeClientOptions(options);
+    const socket = acquireSocket(options, () => {
+      this[kSocket] = socket;
+
+      const session = this[kSession] = createClientSession(options, socket);
+      socket.once('error', (error) => {
+        console.log(error);
+      });
+      socket.on('resume', socketOnResume);
+      socket.on('pause', socketOnPause);
+      socket.on('drain', socketOnDrain);
+      session.on('error', clientSessionOnError(this, socket));
+      session.on('headers', clientSessionOnHeaderComplete);
+      session.on('streamClose', clientSessionOnStreamClose);
+      session.localSettings = options.settings;
+      if (typeof callback === 'function')
+        callback(this);
+
+    });
+  }
+
+  get session() {
+    return this[kSession];
+  }
+
+  get socket() {
+    return this[kSocket];
+  }
+
+  get(options, callback) {
+    options = options || {};
+    options.method = 'GET';
+    this.request(options, callback).end();
+  }
+
+  request(options, callback) {
+    options = options || {};
+    const stream = new Http2Stream(this[kSession], -1, options);
+    const req = new Http2ClientRequest(stream,
+                                       initializeClientOptions(options),
+                                       callback);
+    return req;
+  }
+
+  static request(options, callback) {
+    options = initializeClientOptions(options);
+    createClient(options, (session) => {
+      session.request(options, callback);
+    });
+  }
+
+  static get(options, callback) {
+    options = initializeClientOptions(options);
+    createClient(options, (session) => {
+      session.get(options, callback);
+    });
+  }
+}
+
+class Http2ClientRequest extends Http2Outgoing {
+  constructor(stream, options, callback) {
+    if (typeof options === 'string') {
+      options = new URL(options);
+      if (!options.hostname)
+        throw new Error('Unable to determine the domain name');
+    } else {
+      options = util._extend({}, options);
+    }
+
+    var defaultPort = 80;
+    if (options.protocol === 'https:')
+      defaultPort = 443;
+    options.port = options.port || defaultPort || 80;
+
+    options.hostname = options.hostname || 'localhost';
+    options.method = (options.method || 'GET').toUpperCase();
+    if (!common._checkIsHttpToken(options.method)) {
+      throw new TypeError('Method must be a valid HTTP token');
+    }
+    options.pathname = options.pathname || '/';
+
+    super(stream, options);
+    stream[kRequest] = this;
+
+    var authority = options.hostname;
+    if (options.port)
+      authority += `:${options.port}`;
+    const headers = this[kHeaders] = new Map();
+
+    headers.set(constants.HTTP2_HEADER_SCHEME,
+                options.protocol.slice(0, options.protocol.length - 1));
+    headers.set(constants.HTTP2_HEADER_METHOD, options.method);
+    headers.set(constants.HTTP2_HEADER_AUTHORITY, authority);
+    headers.set(constants.HTTP2_HEADER_PATH, options.pathname);
+
+    if (typeof callback === 'function')
+      this.once('response', callback);
+  }
+
+  setHeader(name, value) {
+    name = String(name).toLowerCase().trim();
+    if (this[kHeaders].has(name)) {
+      const existing = this[kHeaders].get(name);
+      if (Array.isArray(existing)) {
+        existing.push(String(value));
+      } else {
+        this[kHeaders].set(name, [existing, value]);
+      }
+    } else {
+      this[kHeaders].set(name, value);
+    }
+  }
+
+  setTrailer(name, value) {
+    if (!this[kTrailers])
+      this[kTrailers] = new Map();
+    name = String(name).toLowerCase().trim();
+    if (this[kTrailers].has(name)) {
+      const existing = this[kTrailers].get(name);
+      if (Array.isArray(existing)) {
+        existing.push(String(value));
+      } else {
+        this[kTrailers].set(name, [existing, value]);
+      }
+    } else {
+      this[kTrailers].set(name, value);
+    }
+  }
+
+  [kBeginSend]() {
+    if (!this[kHeadersSent]) {
+      this[kHeadersSent] = true;
+      const _handle = this.stream.session.request(mapToHeaders(this[kHeaders]), true);
+      if (_handle instanceof http2.Http2Stream) {
+        this[kId] = _handle.getId();
+        this.stream.once('handle', () => {
+          if (this[kTrailers] instanceof Map) {
+            for (const v of this[kTrailers]) {
+              const key = String(v[0]);
+              const value = v[1];
+              if (Array.isArray(value) && value.length > 0) {
+                for (const item of value)
+                  this.stream.addTrailer(key, String(item));
+              } else {
+                this.stream.addTrailer(key, String(value));
+              }
+            }
+          }
+        });
+        this.stream._handle = _handle;
+      }
+    }
+  }
+
+  end() {
+    super.end();
+  }
+}
+
+class Http2ClientResponse extends Http2Incoming {
+  constructor(stream, headers, options) {
+    super(stream, headers, options);
+  }
+
+  get status() {
+    return this.headers.get(constants.HTTP2_HEADER_STATUS) | 0;
+  }
+}
 
 function createClient(options, callback) {
   return new Http2ClientSession(options, callback);
@@ -1103,6 +1635,8 @@ function createClient(options, callback) {
 
 // Exports
 module.exports = {
+  get: Http2ClientSession.get,
+  request: Http2ClientSession.request,
   Http2Settings: http2.Http2Settings,
   createClient: createClient,
   createServer: createServer,

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -448,6 +448,17 @@ inline void Environment::SetTemplateMethod(v8::Local<v8::FunctionTemplate> that,
   t->SetClassName(name_string);  // NODE_SET_METHOD() compatibility.
 }
 
+inline void Environment::SetAccessor(v8::Local<v8::FunctionTemplate> that,
+                                     const char* name,
+                                     v8::AccessorGetterCallback getter,
+                                     v8::AccessorSetterCallback setter) {
+  v8::Local<v8::ObjectTemplate> instanceTemplate = that->InstanceTemplate();
+  const v8::NewStringType type = v8::NewStringType::kInternalized;
+  instanceTemplate->SetAccessor(
+      v8::String::NewFromUtf8(isolate(), name, type).ToLocalChecked(),
+      getter, setter, v8::Local<v8::Value>(), v8::DEFAULT, v8::DontDelete);
+}
+
 inline v8::Local<v8::Object> Environment::NewInternalFieldObject() {
   v8::MaybeLocal<v8::Object> m_obj =
       generic_internal_field_template()->NewInstance(context());

--- a/src/env.h
+++ b/src/env.h
@@ -513,6 +513,10 @@ class Environment {
   inline void SetTemplateMethod(v8::Local<v8::FunctionTemplate> that,
                                 const char* name,
                                 v8::FunctionCallback callback);
+  inline void SetAccessor(v8::Local<v8::FunctionTemplate> that,
+                          const char* name,
+                          v8::AccessorGetterCallback getter,
+                          v8::AccessorSetterCallback setter = 0);
 
   inline v8::Local<v8::Object> NewInternalFieldObject();
 

--- a/src/env.h
+++ b/src/env.h
@@ -69,6 +69,7 @@ namespace node {
   V(args_string, "args")                                                      \
   V(async, "async")                                                           \
   V(async_queue_string, "_asyncQueue")                                        \
+  V(beginheaders_string, "onBeginHeaders")                                    \
   V(buffer_string, "buffer")                                                  \
   V(bytes_string, "bytes")                                                    \
   V(bytes_parsed_string, "bytesParsed")                                       \
@@ -113,10 +114,10 @@ namespace node {
   V(file_string, "file")                                                      \
   V(fingerprint_string, "fingerprint")                                        \
   V(flags_string, "flags")                                                    \
-  V(goaway_string, "goaway")                                                  \
+  V(goaway_string, "onGoaway")                                                \
   V(gid_string, "gid")                                                        \
   V(handle_string, "handle")                                                  \
-  V(headers_string, "headers")                                                \
+  V(headers_string, "onHeaders")                                              \
   V(heap_total_string, "heapTotal")                                           \
   V(heap_used_string, "heapUsed")                                             \
   V(homedir_string, "homedir")                                                \
@@ -188,7 +189,7 @@ namespace node {
   V(replacement_string, "replacement")                                        \
   V(retry_string, "retry")                                                    \
   V(rss_string, "rss")                                                        \
-  V(rststream_string, "rststream")                                            \
+  V(rststream_string, "onRstStream")                                          \
   V(serial_string, "serial")                                                  \
   V(scopeid_string, "scopeid")                                                \
   V(sent_shutdown_string, "sentShutdown")                                     \
@@ -205,7 +206,7 @@ namespace node {
   V(stack_string, "stack")                                                    \
   V(status_string, "status")                                                  \
   V(stdio_string, "stdio")                                                    \
-  V(streamclose_string, "streamClose")                                        \
+  V(streamclose_string, "onStreamClose")                                      \
   V(subject_string, "subject")                                                \
   V(subjectaltname_string, "subjectaltname")                                  \
   V(sys_string, "sys")                                                        \
@@ -247,10 +248,9 @@ namespace node {
   V(domains_stack_array, v8::Array)                                           \
   V(fs_stats_constructor_function, v8::Function)                              \
   V(generic_internal_field_template, v8::ObjectTemplate)                      \
-  V(http2settings_constructor_template, v8::FunctionTemplate)                 \
-  V(http2stream_constructor_template, v8::FunctionTemplate)                   \
   V(http2headers_constructor_template, v8::FunctionTemplate)                  \
-  V(http2dataprovider_constructor_template, v8::FunctionTemplate)             \
+  V(http2settings_constructor_template, v8::FunctionTemplate)                 \
+  V(http2stream_object, v8::Object)                                           \
   V(jsstream_constructor_template, v8::FunctionTemplate)                      \
   V(module_load_list_array, v8::Array)                                        \
   V(pipe_constructor_template, v8::FunctionTemplate)                          \

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -31,7 +31,6 @@ using v8::Local;
 using v8::Name;
 using v8::Number;
 using v8::Object;
-using v8::ObjectTemplate;
 using v8::PropertyCallbackInfo;
 using v8::String;
 using v8::Value;
@@ -319,52 +318,62 @@ void Http2Headers::GetSize(Local<String> property,
 
 // Http2Stream Statics
 
-Http2Stream::Http2Stream(Environment* env,
-                         Local<Object> wrap,
-                         Http2Session* session,
-                         int32_t stream_id) :
-                         AsyncWrap(env, wrap, AsyncWrap::PROVIDER_HTTP2STREAM),
-                         StreamBase(env),
-                         session_(session),
-                         stream_id_(stream_id) {
-  Wrap(object(), this);
-  str_in_ = NodeBIO::New();
-  str_out_ = NodeBIO::New();
-  NodeBIO::FromBIO(str_in_)->AssignEnvironment(env);
-  NodeBIO::FromBIO(str_out_)->AssignEnvironment(env);
-  provider_.read_callback = Http2Stream::on_read;
-  provider_.source.ptr = this;
-  set_alloc_cb({ OnAllocSelf, this });
-  set_read_cb({ OnReadSelf, this });
-  nghttp2_session_set_stream_user_data(**session, stream_id, this);
+void Http2Stream::New(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(args.IsConstructCall());
+  new Http2Stream(env, args.This());
+}
+
+void Http2Stream::Initialize(Http2Session* session,
+                             int32_t id,
+                             nghttp2_headers_category category) {
+  session_ = session;
+  stream_id_ = id;
+  SetHeaders(category);
+  nghttp2_session_set_stream_user_data(**session, id, this);
+}
+
+// Detaches the Http2Stream instance from the underlying Http2Session
+void Http2Stream::Reset() {
+  if (session_ != nullptr) {
+    if (**session_ != nullptr)
+      nghttp2_session_set_stream_user_data(**session_, stream_id_, nullptr);
+    session_ = nullptr;
+    NodeBIO::FromBIO(str_in_)->Reset();
+    NodeBIO::FromBIO(str_out_)->Reset();
+    outgoing_headers_.clear();
+    outgoing_trailers_.clear();
+    writable_ = true;
+    reading_ = false;
+  }
+}
+
+void Http2Stream::Reinitialize(const FunctionCallbackInfo<Value>& args) {
+  Http2Stream* stream;
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  Environment* env = Environment::GetCurrent(args);
+  CHECK_EQ(env, stream->env());
+  Http2Session* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args[0].As<Object>());
+  nghttp2_headers_category category =
+    static_cast<nghttp2_headers_category>(args[2]->Uint32Value());
+  stream->Initialize(session, args[1]->Int32Value(), category);
+}
+
+void Http2Stream::Reset(const FunctionCallbackInfo<Value>& args) {
+  Http2Stream* stream;
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  stream->Reset();
+}
+
+void Http2Stream::Close(const FunctionCallbackInfo<Value>& args) {
+  Http2Stream* stream;
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  delete stream;
 }
 
 nghttp2_stream* Http2Stream::operator*() {
   return nghttp2_session_find_stream(**session(), id());
-}
-
-void Http2Stream::Detach() {
-  if (!detached_) {
-    CHECK_NE(session_, nullptr);
-    detached_ = true;
-    nghttp2_session_set_stream_user_data(**session_, stream_id_, nullptr);
-    provider_.read_callback = nullptr;
-    provider_.source.ptr = nullptr;
-    session_ = nullptr;
-    // Emit Detached Event on the Http2Stream object to notify
-    // the JS side that the underlying nghttp2_stream handle
-    // is no longer valid.
-    Local<Value> argv[] { env()->detached_string() };
-    Emit(argv, arraysize(argv));
-  }
-}
-
-void Http2Stream::Dispose(const FunctionCallbackInfo<Value>& args) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  ClearWrap(stream->object());
-  stream->persistent().Reset();
-  delete stream;
 }
 
 // Called when chunks of data from a DATA frame are received for this stream.
@@ -393,6 +402,8 @@ void Http2Stream::OnReadSelf(ssize_t nread,
   wrap->EmitData(nread, buf_obj, Local<Object>());
 }
 
+// Passes incoming data received from the peer to the Readable side of
+// the Http2Stream duplex.
 void Http2Stream::EmitPendingData() {
   if (!reading_) return;
   // Rules, emit if there is any data pending in str_in_
@@ -416,140 +427,62 @@ void Http2Stream::EmitPendingData() {
   // If str_in_ is empty and stream is not remote closed, do nothing
 }
 
-// Returns the AsyncWrap uid for the Http2Stream instance. This is
-// provided primarily for debugging and logging purposes.
-void Http2Stream::GetUid(Local<String> property,
-                         const PropertyCallbackInfo<Value>& args) {
+void Http2Stream::GetId(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  Environment* env = stream->env();
-  args.GetReturnValue().Set(Number::New(env->isolate(), stream->get_uid()));
+  args.GetReturnValue().Set(stream->stream_id_);
 }
 
-// Returns the Http2Session associated with this Http2Stream. Returns
-// Undefined if the Http2Stream instance is detached.
-void Http2Stream::GetSession(Local<String> property,
-                             const PropertyCallbackInfo<Value>& info) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  if (stream->detached_) return;
-  info.GetReturnValue().Set(stream->session()->object());
-}
-
-// Returns the HTTP/2 Stream ID as a signed 32-bit integer
-void Http2Stream::GetID(Local<String> property,
-                        const PropertyCallbackInfo<Value>& args) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  args.GetReturnValue().Set(stream->id());
-}
 
 // Returns the current state of the HTTP/2 Stream as provided
 // by nghttp2. If the Http2Stream is detached, the state is
 // reported as NGHTTP2_STREAM_STATE_CLOSED
-void Http2Stream::GetState(Local<String> property,
-                           const PropertyCallbackInfo<Value>& args) {
+void Http2Stream::GetState(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  nghttp2_stream_proto_state state =
-      stream->detached_ ? NGHTTP2_STREAM_STATE_CLOSED :
-                          nghttp2_stream_get_state(**stream);
-  args.GetReturnValue().Set(state);
-}
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
+  Local<Context> context = env->context();
+  Http2Session* session = stream->session();
 
-// Returns the nghttp2 managed summed dependency weight of this
-// Http2Stream instance. If the Http2Stream instance is detached,
-// then a value of 0 is returned.
-void Http2Stream::GetSumDependencyWeight(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& args) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  args.GetReturnValue().Set(
-      stream->detached_ ? 0 :
-          nghttp2_stream_get_sum_dependency_weight(**stream));
-}
+  CHECK(args[0]->IsObject());
+  Local<Object> obj = args[0].As<Object>();
 
-// Returns the nghttp2 managed priority weight of this Http2Stream
-// instance. If the Http2Stream instance is detached, then a value
-// of 0 is returned.
-void Http2Stream::GetWeight(Local<String> property,
-                            const PropertyCallbackInfo<Value>& args) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  args.GetReturnValue().Set(
-      stream->detached_ ? 0 : nghttp2_stream_get_weight(**stream));
-}
+  nghttp2_stream_proto_state state = nghttp2_stream_get_state(**stream);
+  int32_t w = nghttp2_stream_get_weight(**stream);
+  int32_t sdw = nghttp2_stream_get_sum_dependency_weight(**stream);
+  int lclose = nghttp2_session_get_stream_local_close(**session, stream->id());
+  int rclose = nghttp2_session_get_stream_remote_close(**session, stream->id());
+  int32_t size =
+      nghttp2_session_get_stream_local_window_size(**session, stream->id());
 
-// Return the Local Window Size for this Http2Stream instance.
-// If the Http2Stream instance is detached, a value of 0 is returned
-void Http2Stream::GetLocalWindowSize(Local<String> property,
-                                     const PropertyCallbackInfo<Value>& info) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  if (stream->detached_) {
-    info.GetReturnValue().Set(0);
-  } else {
-    Http2Session* session = stream->session();
-    CHECK(**session);
-    info.GetReturnValue().Set(
-        nghttp2_session_get_stream_local_window_size(**session, stream->id()));
-  }
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "state"),
+           Integer::NewFromUnsigned(isolate, state)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "weight"),
+           Integer::New(isolate, w)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "sumDependencyWeight"),
+           Integer::New(isolate, sdw)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "streamLocalClose"),
+           Integer::New(isolate, lclose)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "streamRemoteClose"),
+           Integer::New(isolate, rclose)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "localWindowSize"),
+           Integer::New(isolate, size)).FromJust();
 }
 
 // Modify the Local Window Size of this Http2Stream. This may
 // result in a WINDOW_UPDATE frame being sent to the peer. If
 // the Http2Stream instance is detached, this is a non-op
-void Http2Stream::SetLocalWindowSize(Local<String> property,
-                                     Local<Value> value,
-                                     const PropertyCallbackInfo<void>& info) {
+void Http2Stream::SetLocalWindowSize(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  if (stream->detached_) return;
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());;
   Http2Session* session = stream->session();
   CHECK(**session);
   nghttp2_session_set_local_window_size(
-      **session, NGHTTP2_FLAG_NONE, stream->id(), value->Int32Value());
+      **session, NGHTTP2_FLAG_NONE, stream->id(), args[0]->Int32Value());
 }
 
-// Returns 1 if the local peer half closed the stream, returns
-// 0 if it did not, and -1 if the stream ID is unknown or if
-// the Http2Stream instance is detached.
-void Http2Stream::GetStreamLocalClose(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  if (stream->detached_) {
-    info.GetReturnValue().Set(-1);
-  } else {
-    Http2Session* session = stream->session();
-    CHECK(**session);
-    info.GetReturnValue().Set(
-        nghttp2_session_get_stream_local_close(**session, stream->id()));
-  }
-}
-
-// Returns 1 if the remote peer half closed the stream, returns
-// 0 if it did not, and -1 if the stream ID is unknown or if
-// the Http2Stream instance is detached.
-void Http2Stream::GetStreamRemoteClose(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Stream* stream;
-  ASSIGN_OR_RETURN_UNWRAP(&stream, info.Holder());
-  if (stream->detached_) {
-    info.GetReturnValue().Set(-1);
-  } else {
-    Http2Session* session = stream->session();
-    CHECK(**session);
-    info.GetReturnValue().Set(
-        nghttp2_session_get_stream_remote_close(**session, stream->id()));
-  }
-}
-
-void Http2Stream::Resume() {
-  if (detached_) return;
+void Http2Stream::Resume() {;
   nghttp2_session_resume_data(**session_, id());
   session_->SendIfNecessary();
 }
@@ -572,7 +505,6 @@ void Http2Stream::ResumeData(const FunctionCallbackInfo<Value>& args) {
 void Http2Stream::SendContinue(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  if (stream->detached_) return;
   Http2Session* session = stream->session();
   CHECK(**session);
   nghttp2_nv headers[] {{
@@ -588,12 +520,10 @@ void Http2Stream::SendContinue(const FunctionCallbackInfo<Value>& args) {
 // Initiate sending a response. Response Headers must have been set
 // before calling. This will result in sending an initial HEADERS
 // frame (or multiple), zero or more DATA frames, and zero or more
-// trailing HEADERS frames. If this Http2Stream instance is detached
-// then this is a non-op
+// trailing HEADERS frames.
 void Http2Stream::Respond(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  if (stream->detached_) return;
   Http2Session* session = stream->session();
   CHECK(**session);
   bool nodata = args[0]->BooleanValue();
@@ -612,7 +542,6 @@ void Http2Stream::Respond(const FunctionCallbackInfo<Value>& args) {
 void Http2Stream::SendRstStream(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  if (stream->detached_) return;
   Http2Session* session = stream->session();
   CHECK(**session);
   int rv = nghttp2_submit_rst_stream(**session, NGHTTP2_FLAG_NONE,
@@ -628,7 +557,6 @@ void Http2Stream::SendRstStream(const FunctionCallbackInfo<Value>& args) {
 void Http2Stream::SendPriority(const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  if (stream->detached_) return;
   Http2Session* session = stream->session();
   CHECK(**session);
   Http2Priority priority(args[0]->Int32Value(),
@@ -649,7 +577,6 @@ void Http2Stream::ChangeStreamPriority(
     const FunctionCallbackInfo<Value>& args) {
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  if (stream->detached_) return;
   Http2Session* session = stream->session();
   CHECK(**session);
   Http2Priority priority(args[0]->Int32Value(),
@@ -669,10 +596,9 @@ void Http2Stream::SendPushPromise(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(env->isolate());
   Http2Stream* stream;
   ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
-  if (stream->detached_) return;
   Http2Session* session = stream->session();
   CHECK(**session);
-  if (!session->IsServer()) {
+  if (session->type_ == SESSION_TYPE_CLIENT) {
     return env->ThrowError("Client Http2Session instances cannot use push");
   }
   Http2Headers* headers;
@@ -685,19 +611,23 @@ void Http2Stream::SendPushPromise(const FunctionCallbackInfo<Value>& args) {
                                   **headers, headers->Size(),
                                   stream);
   session->EmitErrorIfFail(rv);
-  args.GetReturnValue().Set(
-      Http2Session::CreateStream(env, session, rv)->object());
+
+  if (rv > 0) {
+    Local<Object> obj = env->http2stream_object()->Clone();
+    Http2Stream* ret = new Http2Stream(env, obj);
+    ret->Initialize(session, rv, NGHTTP2_HCAT_REQUEST);
+    args.GetReturnValue().Set(ret->object());
+  }
 }
 
 // Called when end() has been called on the Writable side of the Http2Stream
 // Duplex. Sets the internal writable state to false and resumes sending
 // any additional data pending so long as the Http2Stream is not detached.
-int Http2Stream::DoShutdown(ShutdownWrap* req_wrap) {
-  writable_ = false;
-  if (!detached_) Resume();
-  req_wrap->Dispatched();
-  req_wrap->Done(0);
-  return 0;
+void Http2Stream::FinishedWriting(const FunctionCallbackInfo<Value>& args) {
+  Http2Stream* stream;
+  ASSIGN_OR_RETURN_UNWRAP(&stream, args.Holder());
+  stream->writable_ = false;
+  stream->Resume();
 }
 
 // Called when data has been written on the Writable side of the Http2Stream
@@ -716,13 +646,13 @@ int Http2Stream::DoWrite(WriteWrap* w,
   // If the Http2Stream instance has been detached, then it
   // does not do any good to keep storing the data.
   // TODO(jasnell): Later could likely make this a CHECK
-  if (!detached_) {
-    for (size_t i = 0; i < count; i++) {
-      // Only attempt to write if the buf is not empty
-      if (bufs[i].len > 0)
-        NodeBIO::FromBIO(str_out_)->Write(bufs[i].base, bufs[i].len);
-    }
+
+  for (size_t i = 0; i < count; i++) {
+    // Only attempt to write if the buf is not empty
+    if (bufs[i].len > 0)
+      NodeBIO::FromBIO(str_out_)->Write(bufs[i].base, bufs[i].len);
   }
+
   // Whether detached or not, call dispatch and done.
   w->Dispatched();
   w->Done(0);
@@ -730,12 +660,11 @@ int Http2Stream::DoWrite(WriteWrap* w,
 }
 
 bool Http2Stream::IsAlive() {
-  return !detached_ &&
-         nghttp2_stream_get_state(**this) != NGHTTP2_STREAM_STATE_CLOSED;
+  return nghttp2_stream_get_state(**this) != NGHTTP2_STREAM_STATE_CLOSED;
 }
 
 bool Http2Stream::IsClosing() {
-  return detached_;
+  return false;
 }
 
 // Upon calling ReadStart, the Http2Stream instance will immediately
@@ -767,26 +696,29 @@ ssize_t Http2Stream::on_read(nghttp2_session* session,
                              nghttp2_data_source* source,
                              void* user_data) {
   Http2Stream* stream = static_cast<Http2Stream*>(source->ptr);
-  CHECK(!stream->detached_);
 
   NodeBIO* bio = NodeBIO::FromBIO(stream->str_out_);
 
   ssize_t amount = bio->Read(reinterpret_cast<char*>(buf), length);
-
-  if (amount == 0 && stream->writable_) {
-    return NGHTTP2_ERR_DEFERRED;
+  bool done = false;
+  if (amount == 0) {
+    if (stream->writable_)
+      return NGHTTP2_ERR_DEFERRED;
+    done = true;
+  } else if (!stream->writable_ && bio->Length() == 0) {
+    done = true;
   }
-  if (!stream->writable_ && bio->Length() == 0) {
+  if (done) {
     *flags |= NGHTTP2_DATA_FLAG_EOF;
-    if (stream->OutgoingTrailersCount() > 0) {
-      // If there are any trailing headers they have to be
-      // queued up to send here.
-      *flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
-        nghttp2_submit_trailer(session,
-                                stream->id(),
-                                stream->OutgoingTrailers(),
-                                stream->OutgoingTrailersCount());
-    }
+      if (stream->OutgoingTrailersCount() > 0) {
+        // If there are any trailing headers they have to be
+        // queued up to send here.
+        *flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+          nghttp2_submit_trailer(session,
+                                  stream->id(),
+                                  stream->OutgoingTrailers(),
+                                  stream->OutgoingTrailersCount());
+      }
   }
   return amount;
 }
@@ -823,49 +755,95 @@ void Http2Stream::AddTrailer(const FunctionCallbackInfo<Value>& args) {
 
 // Http2Session Statics
 
-// The Http2Session class wraps an individual nghttp2_session struct.
-Http2Session::Http2Session(Environment* env,
-                           Local<Object> wrap,
-                           enum http2_session_type type,
-                           Local<Value> options,
-                           Local<Value> external) :
-                           AsyncWrap(env, wrap,
-                                     AsyncWrap::PROVIDER_HTTP2SESSION),
-                           type_(type) {
-  MakeWeak<Http2Session>(this);
-  nghttp2_session_callbacks* cb;
-  nghttp2_session_callbacks_new(&cb);
+// Create a new Http2Session instance. The first argument is the numeric
+// indicator of the type of session to create (see enum http2_session_type).
+// The second argument is the options object. The third argument is the
+// stream to capture.
+void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK(args.IsConstructCall());
+  new Http2Session(env, args.This());
+}
 
-#define SET_SESSION_CALLBACK(callbacks, name)                                 \
-  nghttp2_session_callbacks_set_##name##_callback(callbacks, name);
+// (Re)Initialize the Http2Session instance.
+// The first argument is the numeric indicator of the type of session_ctx
+// The second argument is the options object.
+// The third argument is the stream to capture.
+void Http2Session::Reinitialize(const FunctionCallbackInfo<Value>& args) {
+  Http2Session* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  Environment* env = Environment::GetCurrent(args);
+  CHECK_EQ(env, session->env());
 
-  SET_SESSION_CALLBACK(cb, send)
-  SET_SESSION_CALLBACK(cb, on_frame_recv)
-  SET_SESSION_CALLBACK(cb, on_stream_close)
-  SET_SESSION_CALLBACK(cb, on_header)
-  SET_SESSION_CALLBACK(cb, on_begin_headers)
-  SET_SESSION_CALLBACK(cb, on_data_chunk_recv)
-  SET_SESSION_CALLBACK(cb, select_padding);
+  enum http2_session_type type =
+      static_cast<enum http2_session_type>(args[0]->Int32Value());
+  CHECK(type == SESSION_TYPE_SERVER || type == SESSION_TYPE_CLIENT);
+  CHECK(args[1]->IsObject());
+  CHECK(args[2]->IsExternal());
 
-#undef SET_SESSION_CALLBACK
+  session->Initialize(env, type, args[1].As<Object>(), args[2].As<External>());
+}
 
+void Http2Session::Initialize(Environment* env,
+                              enum http2_session_type type,
+                              Local<Value> options,
+                              Local<External> external) {
+  type_ = type;
   Http2Options opts(env, options);
   if (type == SESSION_TYPE_CLIENT) {
-    nghttp2_session_client_new2(&session_, cb, this, *opts);
+    nghttp2_session_client_new2(&session_, cb_, this, *opts);
   } else {
-    nghttp2_session_server_new2(&session_, cb, this, *opts);
+    nghttp2_session_server_new2(&session_, cb_, this, *opts);
   }
-  nghttp2_session_callbacks_del(cb);
+  Consume(external);
+}
 
-  // When the Http2Session instance is created, it takes
-  // over consumption of the underlying stream in order
-  // to optimize reads and writes.
-  if (!external.IsEmpty() && external->IsExternal()) {
-    Consume(external);
+// Capture the stream that will this session will use to send and receive data
+void Http2Session::Consume(Local<External> external) {
+  CHECK(prev_alloc_cb_.is_empty());
+  StreamBase* stream = static_cast<StreamBase*>(external->Value());
+  CHECK_NE(stream, nullptr);
+  stream->Consume();
+  stream_ = stream;
+  prev_alloc_cb_ = stream->alloc_cb();
+  prev_read_cb_ = stream->read_cb();
+  stream->set_alloc_cb({ Http2Session::OnAllocImpl, this });
+  stream->set_read_cb({ Http2Session::OnReadImpl, this });
+}
+
+// Release the captured stream (only if currently captured)
+void Http2Session::Unconsume() {
+  if (prev_alloc_cb_.is_empty())
+    return;
+  stream_->set_alloc_cb(prev_alloc_cb_);
+  stream_->set_read_cb(prev_read_cb_);
+  prev_alloc_cb_.clear();
+  prev_read_cb_.clear();
+  stream_ = nullptr;
+}
+
+void Http2Session::Reset() {
+  if (session_ != nullptr) {
+    Unconsume();
+    nghttp2_session_del(session_);
+    session_ = nullptr;
   }
 }
 
-static const size_t kAllocBufferSize = 64 * 1024;
+void Http2Session::Reset(const FunctionCallbackInfo<Value>& args) {
+  Http2Session* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  session->Reset();
+}
+
+void Http2Session::Close(const FunctionCallbackInfo<Value>& args) {
+  Http2Session* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  session->Reset();
+  ClearWrap(session->object());
+  session->persistent().Reset();
+  delete session;
+}
 
 // Used to allocate buffer space when reading from the
 // underlying stream.
@@ -908,44 +886,6 @@ void Http2Session::OnReadImpl(ssize_t nread,
   session->SendIfNecessary();
 }
 
-// Release the captured stream. Currently this is done
-// only when the Http2Stream is deconstructed.
-void Http2Session::Unconsume() {
-  if (prev_alloc_cb_.is_empty())
-    return;
-  stream_->set_alloc_cb(prev_alloc_cb_);
-  stream_->set_read_cb(prev_read_cb_);
-  prev_alloc_cb_.clear();
-  prev_read_cb_.clear();
-  stream_ = nullptr;
-}
-
-// Capture the stream that will this session will use to send and
-// receive data
-void Http2Session::Consume(Local<Value> external) {
-  Local<External> stream_obj = external.As<External>();
-  StreamBase* stream = static_cast<StreamBase*>(stream_obj->Value());
-  CHECK_NE(stream, nullptr);
-
-  stream->Consume();
-
-  stream_ = stream;
-  prev_alloc_cb_ = stream->alloc_cb();
-  prev_read_cb_ = stream->read_cb();
-
-  stream->set_alloc_cb({ Http2Session::OnAllocImpl, this });
-  stream->set_read_cb({ Http2Session::OnReadImpl, this });
-}
-
-// Gets the AsyncWrap uid of the Http2Session object. This is provided
-// primarily for debugging purposes.
-void Http2Session::GetUid(Local<String> property,
-                          const PropertyCallbackInfo<Value>& args) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  Environment* env = session->env();
-  args.GetReturnValue().Set(Number::New(env->isolate(), session->get_uid()));
-}
 
 // Called by nghttp2 when there is data to send on this session.
 // This is generally trigged by calling the Http2Session::SendIfNecessary
@@ -966,19 +906,13 @@ ssize_t Http2Session::send(nghttp2_session* session,
           ->NewInstance(env->context()).ToLocalChecked();
 
   auto cb = [](WriteWrap* req, int status) {};
-  WriteWrap* write_req = WriteWrap::New(env,
-                                        req_wrap_obj,
-                                        nullptr,
-                                        cb);
+  WriteWrap* write_req = WriteWrap::New(env, req_wrap_obj, nullptr, cb);
 
   uv_buf_t buf[] {
-    uv_buf_init(
-        const_cast<char*>(reinterpret_cast<const char*>(data)),
-        length)
+    uv_buf_init(const_cast<char*>(reinterpret_cast<const char*>(data)), length)
   };
-  int err = session_obj->stream_->DoWrite(write_req, buf, 1, nullptr);
 
-  if (err) {
+  if (session_obj->stream_->DoWrite(write_req, buf, arraysize(buf), nullptr)) {
     // Ignore Errors
     write_req->Dispose();
   }
@@ -999,11 +933,10 @@ int Http2Session::on_rst_stream_frame(Http2Session* session,
   Context::Scope context_scope(env->context());
 
   Local<Value> argv[] {
-    env->rststream_string(),
     Integer::New(env->isolate(), id),
     Integer::NewFromUnsigned(env->isolate(), rst.error_code)
   };
-  session->Emit(argv, arraysize(argv));
+  session->Emit(env->rststream_string(), argv, arraysize(argv));
 
   return 0;
 }
@@ -1033,12 +966,11 @@ int Http2Session::on_goaway_frame(Http2Session* session,
   }
 
   Local<Value> argv[] {
-    env->goaway_string(),
     Integer::NewFromUnsigned(isolate, goaway.error_code),
     Integer::New(isolate, goaway.last_stream_id),
     opaque_data
   };
-  session->Emit(argv, arraysize(argv));
+  session->Emit(env->goaway_string(), argv, arraysize(argv));
 
   return 0;
 }
@@ -1067,22 +999,22 @@ int Http2Session::on_data_chunk_recv(nghttp2_session* session,
 // or trailers block. nghttp2 makes the appropriate determination
 // based on the current state of the underlying nghttp2_stream.
 int Http2Session::on_headers_frame(Http2Session* session,
-                                   Http2Stream* stream,
+                                   int32_t id,
                                    const nghttp2_frame_hd hd,
                                    const nghttp2_headers headers) {
   Environment* env = session->env();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
-
+  Http2Stream* stream =
+      Http2Stream::GetFromSession(**session, id);
+  CHECK_NE(stream, nullptr);
   Local<Value> argv[] {
-    env->headers_string(),
     stream->object(),
     Integer::NewFromUnsigned(env->isolate(), hd.flags),
     stream->GetHeaders(),
     Integer::NewFromUnsigned(env->isolate(), stream->GetHeadersCategory())
   };
-  session->Emit(argv, arraysize(argv));
-
+  session->Emit(env->headers_string(), argv, arraysize(argv));
   stream->ClearHeaders();
   return 0;
 }
@@ -1095,7 +1027,6 @@ int Http2Session::on_frame_recv(nghttp2_session *session,
                                 void *user_data) {
   Http2Session* session_obj = static_cast<Http2Session*>(user_data);
   CHECK_NE(session_obj, nullptr);
-  Http2Stream* stream;
   switch (frame->hd.type) {
   case NGHTTP2_RST_STREAM:
     return on_rst_stream_frame(session_obj,
@@ -1103,11 +1034,14 @@ int Http2Session::on_frame_recv(nghttp2_session *session,
                                frame->hd,
                                frame->rst_stream);
   case NGHTTP2_GOAWAY:
-    return on_goaway_frame(session_obj, frame->hd, frame->goaway);
+    return on_goaway_frame(session_obj,
+                           frame->hd,
+                           frame->goaway);
   case NGHTTP2_HEADERS:
-    stream = Http2Stream::GetFromSession(session, frame->hd.stream_id);
-    CHECK_NE(stream, nullptr);
-    return on_headers_frame(session_obj, stream, frame->hd, frame->headers);
+    return on_headers_frame(session_obj,
+                            frame->hd.stream_id,
+                            frame->hd,
+                            frame->headers);
   default:
     return 0;
   }
@@ -1123,20 +1057,14 @@ int Http2Session::on_stream_close(nghttp2_session *session,
   Http2Session* session_obj = static_cast<Http2Session*>(user_data);
   CHECK_NE(session_obj, nullptr);
   Environment* env = session_obj->env();
-  HandleScope handle_scope(env->isolate());
-  Context::Scope context_scope(env->context());
-  Http2Stream* stream = Http2Stream::GetFromSession(session, stream_id);
-  CHECK_NE(stream, nullptr);
-  stream->Detach();
+  Isolate* isolate = env->isolate();
+  HandleScope handle_scope(isolate);
 
-  // TODO(jasnell): Collapse this into the detach event. Perhaps use
-  // "close" instead of "detach" as the event name
   Local<Value> argv[] {
-    env->streamclose_string(),
-    stream->object(),
-    Integer::NewFromUnsigned(env->isolate(), error_code)
+    Integer::New(isolate, stream_id),
+    Integer::NewFromUnsigned(isolate, error_code)
   };
-  session_obj->Emit(argv, arraysize(argv));
+  session_obj->Emit(env->streamclose_string(), argv, arraysize(argv));
 
   return 0;
 }
@@ -1168,12 +1096,18 @@ int Http2Session::on_begin_headers(nghttp2_session* session,
   Http2Session* session_obj = static_cast<Http2Session*>(user_data);
   CHECK_NE(session_obj, nullptr);
   Environment* env = session_obj->env();
-  Http2Stream* stream =
-      Http2Stream::GetFromSession(session, frame->hd.stream_id);
-  if (stream == nullptr)
-    stream = CreateStream(env, session_obj, frame->hd.stream_id);
-  CHECK_NE(stream, nullptr);
-  stream->SetHeaders(frame->headers.cat);
+  Isolate* isolate = env->isolate();
+  int32_t id = frame->hd.stream_id;
+  Http2Stream* stream = Http2Stream::GetFromSession(session, id);
+  if (stream == nullptr) {
+    EscapableHandleScope scope(isolate);
+    Local<Object> obj = env->http2stream_object()->Clone();
+    Http2Stream* stream = new Http2Stream(env, scope.Escape(obj));
+    stream->Initialize(session_obj, id, frame->headers.cat);
+  } else {
+    // Otherwise, begin working on the new headers block
+    stream->SetHeaders(frame->headers.cat);
+  }
   return 0;
 }
 
@@ -1189,171 +1123,62 @@ ssize_t Http2Session::select_padding(nghttp2_session *session,
   return frame->hd.length;
 }
 
-// Creates and returns a new Http2Stream instance that wraps an
-// nghttp2_stream.
-Http2Stream* Http2Session::CreateStream(Environment* env,
-                                        Http2Session* session,
-                                        uint32_t stream_id) {
-  HandleScope scope(env->isolate());
-  CHECK_EQ(env->http2stream_constructor_template().IsEmpty(), false);
-  Local<Function> constructor =
-      env->http2stream_constructor_template()->GetFunction();
-  CHECK_EQ(constructor.IsEmpty(), false);
-  Local<Object> obj = constructor->NewInstance(env->context()).ToLocalChecked();
-  return new Http2Stream(env, obj, session, stream_id);
-}
-
-// Create a new Http2Session instance. The first argument is the numeric
-// indicator of the type of session to create (see enum http2_session_type).
-// The second argument is the options object. The third argument is the
-// stream to capture.
-void Http2Session::New(const FunctionCallbackInfo<Value>& args) {
+void Http2Session::GetState(const FunctionCallbackInfo<Value>& args) {
+  Http2Session* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  CHECK(args[0]->IsObject());
+  Local<Object> obj = args[0].As<Object>();
   Environment* env = Environment::GetCurrent(args);
-  if (!args.IsConstructCall())
-    return env->ThrowTypeError("Class constructor Http2Session cannot "
-                               "be invoked without 'new'");
-  enum http2_session_type type =
-      static_cast<enum http2_session_type>(args[0]->Int32Value());
-  if (type != SESSION_TYPE_SERVER && type != SESSION_TYPE_CLIENT)
-    return env->ThrowTypeError("Invalid HTTP/2 session type");
+  Isolate* isolate = env->isolate();
+  Local<Context> context = env->context();
 
-  new Http2Session(env, args.This(), type, args[1], args[2]);
+  int32_t elws = nghttp2_session_get_effective_local_window_size(**session);
+  int32_t erdl = nghttp2_session_get_effective_recv_data_length(**session);
+  uint32_t nextid = nghttp2_session_get_next_stream_id(**session);
+  int32_t slws = nghttp2_session_get_local_window_size(**session);
+  int32_t lpsid = nghttp2_session_get_last_proc_stream_id(**session);
+  int32_t srws = nghttp2_session_get_remote_window_size(**session);
+  size_t outbound_size = nghttp2_session_get_outbound_queue_size(**session);
+  size_t ddts = nghttp2_session_get_hd_deflate_dynamic_table_size(**session);
+  size_t idts = nghttp2_session_get_hd_inflate_dynamic_table_size(**session);
+
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "effectiveLocalWindowSize"),
+           Integer::New(isolate, elws)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "effectiveRecvDataLength"),
+           Integer::New(isolate, erdl)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "nextStreamID"),
+           Integer::NewFromUnsigned(isolate, nextid)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "localWindowSize"),
+           Integer::New(isolate, slws)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "lastProcStreamID"),
+           Integer::New(isolate, lpsid)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "remoteWindowSize"),
+           Integer::New(isolate, srws)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "outboundQueueSize"),
+           Integer::NewFromUnsigned(isolate, outbound_size)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "deflateDynamicTableSize"),
+           Integer::NewFromUnsigned(isolate, ddts)).FromJust();
+  obj->Set(context, FIXED_ONE_BYTE_STRING(isolate, "inflateDynamicTableSize"),
+           Integer::NewFromUnsigned(isolate, idts)).FromJust();
 }
 
-// Returns true if this Http2Session is expecting to receive data
-void Http2Session::GetWantRead(Local<String> property,
-                               const PropertyCallbackInfo<Value>& info) {
+void Http2Session::SetNextStreamID(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(nghttp2_session_want_read(**session) != 0);
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  nghttp2_session_set_next_stream_id(**session, args[0]->Int32Value());
 }
 
-// Returns true if this Http2Stream has data queued up to send
-void Http2Session::GetWantWrite(Local<String> property,
-                                const PropertyCallbackInfo<Value>& info) {
+void Http2Session::SetLocalWindowSize(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(nghttp2_session_want_write(**session) != 0);
-}
-
-// Returns the Http2Session type identifier.
-void Http2Session::GetType(Local<String> property,
-                           const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(session->type_);
-}
-
-
-void Http2Session::GetEffectiveLocalWindowSize(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(
-      nghttp2_session_get_effective_local_window_size(**session));
-}
-
-
-void Http2Session::GetEffectiveRecvDataLength(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(
-      nghttp2_session_get_effective_recv_data_length(**session));
-}
-
-
-void Http2Session::GetNextStreamID(Local<String> property,
-                                   const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(nghttp2_session_get_next_stream_id(**session));
-}
-
-
-void Http2Session::SetNextStreamID(Local<String> property,
-                                   Local<Value> value,
-                                   const PropertyCallbackInfo<void>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  int32_t id = value->Int32Value();
-  nghttp2_session_set_next_stream_id(**session, id);
-}
-
-
-void Http2Session::GetLocalWindowSize(Local<String> property,
-                                   const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(nghttp2_session_get_local_window_size(**session));
-}
-
-void Http2Session::SetLocalWindowSize(Local<String> property,
-                                      Local<Value> value,
-                                      const PropertyCallbackInfo<void>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
   nghttp2_session_set_local_window_size(
-      **session, NGHTTP2_FLAG_NONE, 0, value->Int32Value());
-}
-
-void Http2Session::GetLastProcStreamID(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(nghttp2_session_get_last_proc_stream_id(**session));
-}
-
-
-void Http2Session::GetRemoteWindowSize(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  info.GetReturnValue().Set(nghttp2_session_get_remote_window_size(**session));
-}
-
-
-void Http2Session::GetOutboundQueueSize(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  size_t size = nghttp2_session_get_outbound_queue_size(**session);
-  Environment* env = session->env();
-  info.GetReturnValue().Set(Integer::New(env->isolate(), size));
-}
-
-
-void Http2Session::GetDeflateDynamicTableSize(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  size_t size = nghttp2_session_get_hd_deflate_dynamic_table_size(**session);
-  Environment* env = session->env();
-  info.GetReturnValue().Set(Integer::New(env->isolate(), size));
-}
-
-
-void Http2Session::GetInflateDynamicTableSize(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
-  size_t size = nghttp2_session_get_hd_inflate_dynamic_table_size(**session);
-  Environment* env = session->env();
-  info.GetReturnValue().Set(Integer::New(env->isolate(), size));
+      **session, NGHTTP2_FLAG_NONE, 0, args[0]->Int32Value());
 }
 
 void Http2Session::GetLocalSettings(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
+    const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
   Environment* env = session->env();
   HandleScope scope(env->isolate());
   CHECK_EQ(env->http2settings_constructor_template().IsEmpty(), false);
@@ -1362,20 +1187,17 @@ void Http2Session::GetLocalSettings(
   CHECK_EQ(constructor.IsEmpty(), false);
   Local<Object> obj = constructor->NewInstance(env->context()).ToLocalChecked();
   new Http2Settings(env, obj, session, true);
-  info.GetReturnValue().Set(obj);
+  args.GetReturnValue().Set(obj);
 }
 
-void Http2Session::SetLocalSettings(
-  Local<String> property,
-  Local<Value> value,
-  const PropertyCallbackInfo<void>& info) {
+void Http2Session::SetLocalSettings(const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
   Environment* env = session->env();
 
   Http2Settings* settings;
-  THROW_AND_RETURN_UNLESS_HTTP2SETTINGS(env, value);
-  ASSIGN_OR_RETURN_UNWRAP(&settings, value.As<Object>());
+  THROW_AND_RETURN_UNLESS_HTTP2SETTINGS(env, args[0]);
+  ASSIGN_OR_RETURN_UNWRAP(&settings, args[0].As<Object>());
   std::vector<nghttp2_settings_entry> entries;
   settings->CollectSettings(&entries);
 
@@ -1385,10 +1207,9 @@ void Http2Session::SetLocalSettings(
 }
 
 void Http2Session::GetRemoteSettings(
-    Local<String> property,
-    const PropertyCallbackInfo<Value>& info) {
+    const FunctionCallbackInfo<Value>& args) {
   Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, info.Holder());
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
   Environment* env = session->env();
 
   HandleScope scope(env->isolate());
@@ -1398,19 +1219,7 @@ void Http2Session::GetRemoteSettings(
   CHECK_EQ(constructor.IsEmpty(), false);
   Local<Object> obj = constructor->NewInstance(env->context()).ToLocalChecked();
   new Http2Settings(env, obj, session, false);
-  info.GetReturnValue().Set(obj);
-}
-
-// Releases state but does not completely tear everything down. Currently
-// this is mainly used to release the consumption of the underlying stream
-// once the socket has been destroyed. This will effectively make the
-// session a non-op. Because the Ht2Session constructor calls MakeWeak,
-// the ~Http2Session destructor wil called to clean up the rest when
-// the object eventually gets garbage collected.
-void Http2Session::Destroy(const FunctionCallbackInfo<Value>& args) {
-  Http2Session* session;
-  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
-  session->Unconsume();
+  args.GetReturnValue().Set(obj);
 }
 
 // Signals termination of the nghttp2_session by sending a GOAWAY
@@ -1447,6 +1256,43 @@ void Http2Session::GracefulTerminate(const FunctionCallbackInfo<Value>& args) {
   session->EmitErrorIfFail(rv);
 }
 
+// Initiate sending a request. Request headers must be passed as an
+// argument in the form of an Http2Headers object. This will result
+// in sending an initial HEADERS frame (or multiple), zero or more
+// DATA frames, and zero or more trailing HEADERS frames.
+void Http2Session::Request(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
+
+  Http2Session* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  CHECK(**session);
+
+  EscapableHandleScope scope(isolate);
+  Local<Object> obj = env->http2stream_object()->Clone();
+  Http2Stream* stream = new Http2Stream(env, scope.Escape(obj));
+
+  Http2Headers* headers;
+  THROW_AND_RETURN_UNLESS_HTTP2HEADERS(env, args[0]);
+  ASSIGN_OR_RETURN_UNWRAP(&headers, args[0].As<Object>());
+
+  bool nodata = args[1]->BooleanValue();
+  nghttp2_data_provider* provider = nodata ? nullptr : stream->provider();
+
+  const nghttp2_priority_spec* pri = NULL;
+
+  int32_t rv = nghttp2_submit_request(**session, pri,
+                                      **headers, headers->Size(),
+                                      provider, stream);
+
+  session->EmitErrorIfFail(rv);
+
+  if (rv > 0) {
+    stream->Initialize(session, rv, NGHTTP2_HCAT_RESPONSE);
+    args.GetReturnValue().Set(stream->object());
+  }
+}
+
 void HttpErrorString(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   args.GetReturnValue().Set(
@@ -1467,170 +1313,80 @@ void Initialize(Local<Object> target,
   env->SetMethod(target, "nghttp2ErrorString", HttpErrorString);
 
   Local<String> http2HeadersClassName =
-    FIXED_ONE_BYTE_STRING(isolate, "Http2Headers");
+    String::NewFromUtf8(isolate, "Http2Headers",
+                        v8::NewStringType::kInternalized).ToLocalChecked();
   Local<String> http2SessionClassName =
-    FIXED_ONE_BYTE_STRING(isolate, "Http2Session");
+    String::NewFromUtf8(isolate, "Http2Session",
+                        v8::NewStringType::kInternalized).ToLocalChecked();
   Local<String> http2StreamClassName =
-    FIXED_ONE_BYTE_STRING(isolate, "Http2Stream");
+    String::NewFromUtf8(isolate, "Http2Stream",
+                        v8::NewStringType::kInternalized).ToLocalChecked();
   Local<String> http2SettingsClassName =
-    FIXED_ONE_BYTE_STRING(isolate, "Http2Settings");
+    String::NewFromUtf8(isolate, "Http2Settings",
+                        v8::NewStringType::kInternalized).ToLocalChecked();
 
   // Persistent FunctionTemplate for Http2Stream. Instances of this
   // class are only intended to be created by Http2Session::CreateStream
   // so the constructor is not exposed via the binding.
-  Local<FunctionTemplate> stream_constructor_template =
-     Local<FunctionTemplate>(FunctionTemplate::New(isolate));
-  stream_constructor_template->SetClassName(http2StreamClassName);
-  Local<ObjectTemplate> stream_template =
-      stream_constructor_template->InstanceTemplate();
-  stream_template->SetInternalFieldCount(1);
-  stream_template->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "uid"),
-      Http2Stream::GetUid,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  stream_template->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "session"),
-      Http2Stream::GetSession,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  stream_template->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "id"),
-      Http2Stream::GetID,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  stream_template->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "state"),
-      Http2Stream::GetState,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  stream_template->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "weight"),
-      Http2Stream::GetWeight,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  stream_template->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "sumDependencyWeight"),
-      Http2Stream::GetSumDependencyWeight,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  stream_template->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "localClose"),
-      Http2Stream::GetStreamLocalClose,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  stream_template->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "remoteClose"),
-      Http2Stream::GetStreamRemoteClose,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  stream_template->SetAccessor(
-    FIXED_ONE_BYTE_STRING(isolate, "localWindowSize"),
-    Http2Stream::GetLocalWindowSize,
-    Http2Stream::SetLocalWindowSize,
-    Local<Value>(),
-    v8::DEFAULT,
-    v8::DontDelete);
-  env->SetProtoMethod(stream_constructor_template,
-                      "changeStreamPriority",
-                      Http2Stream::ChangeStreamPriority);
-  env->SetProtoMethod(stream_constructor_template,
-                      "respond",
-                      Http2Stream::Respond);
-  env->SetProtoMethod(stream_constructor_template,
-                      "resumeData",
-                      Http2Stream::ResumeData);
-  env->SetProtoMethod(stream_constructor_template,
-                      "sendContinue",
-                      Http2Stream::SendContinue);
-  env->SetProtoMethod(stream_constructor_template,
-                      "sendPriority",
-                      Http2Stream::SendPriority);
-  env->SetProtoMethod(stream_constructor_template,
-                      "sendRstStream",
-                      Http2Stream::SendRstStream);
-  env->SetProtoMethod(stream_constructor_template,
-                      "sendPushPromise",
-                      Http2Stream::SendPushPromise);
-  env->SetProtoMethod(stream_constructor_template,
-                      "addHeader",
-                      Http2Stream::AddHeader);
-  env->SetProtoMethod(stream_constructor_template,
-                      "addTrailer",
-                      Http2Stream::AddTrailer);
-  env->SetProtoMethod(stream_constructor_template,
-                      "destroy",
-                      Http2Stream::Dispose);
-  StreamBase::AddMethods<Http2Stream>(env, stream_constructor_template,
-                                      StreamBase::kFlagHasWritev);
+  Local<FunctionTemplate> stream = env->NewFunctionTemplate(Http2Stream::New);
+  stream->SetClassName(http2StreamClassName);
+  stream->InstanceTemplate()->SetInternalFieldCount(1);
 
-  env->set_http2stream_constructor_template(stream_constructor_template);
-  target->Set(http2StreamClassName, stream_constructor_template->GetFunction());
+  env->SetProtoMethod(stream, "close", Http2Stream::Close);
+  env->SetProtoMethod(stream, "reset", Http2Stream::Reset);
+  env->SetProtoMethod(stream, "reinitialize", Http2Stream::Reinitialize);
+  env->SetProtoMethod(stream, "getId", Http2Stream::GetId);
+  env->SetProtoMethod(stream, "getState", Http2Stream::GetState);
+  env->SetProtoMethod(stream, "setLocalWindowSize",
+                      Http2Stream::SetLocalWindowSize);
+
+  env->SetProtoMethod(stream, "changeStreamPriority",
+                      Http2Stream::ChangeStreamPriority);
+  env->SetProtoMethod(stream, "respond", Http2Stream::Respond);
+  env->SetProtoMethod(stream, "resume", Http2Stream::ResumeData);
+  env->SetProtoMethod(stream, "sendContinue", Http2Stream::SendContinue);
+  env->SetProtoMethod(stream, "sendPriority", Http2Stream::SendPriority);
+  env->SetProtoMethod(stream, "sendRstStream", Http2Stream::SendRstStream);
+  env->SetProtoMethod(stream, "sendPushPromise", Http2Stream::SendPushPromise);
+  env->SetProtoMethod(stream, "addHeader", Http2Stream::AddHeader);
+  env->SetProtoMethod(stream, "addTrailer", Http2Stream::AddTrailer);
+  env->SetProtoMethod(stream, "finishedWriting", Http2Stream::FinishedWriting);
+  StreamBase::AddMethods<Http2Stream>(env, stream, StreamBase::kFlagHasWritev |
+                                                   StreamBase::kFlagNoShutdown);
+  env->set_http2stream_object(
+    stream->GetFunction()->NewInstance(env->context()).ToLocalChecked());
+  target->Set(http2StreamClassName, stream->GetFunction());
 
   // Http2Settings Template
   Local<FunctionTemplate> settings =
       env->NewFunctionTemplate(Http2Settings::New);
   settings->SetClassName(http2SettingsClassName);
-  Local<ObjectTemplate> settings_object = settings->InstanceTemplate();
-  settings_object->SetInternalFieldCount(1);
-  settings_object->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "headerTableSize"),
-      Http2Settings::GetHeaderTableSize,
-      Http2Settings::SetHeaderTableSize,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  settings_object->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "enablePush"),
-      Http2Settings::GetEnablePush,
-      Http2Settings::SetEnablePush,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  settings_object->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "maxConcurrentStreams"),
-      Http2Settings::GetMaxConcurrentStreams,
-      Http2Settings::SetMaxConcurrentStreams,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  settings_object->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "initialWindowSize"),
-      Http2Settings::GetInitialWindowSize,
-      Http2Settings::SetInitialWindowSize,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  settings_object->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "maxFrameSize"),
-      Http2Settings::GetMaxFrameSize,
-      Http2Settings::SetMaxFrameSize,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  settings_object->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "maxHeaderListSize"),
-      Http2Settings::GetMaxHeaderListSize,
-      Http2Settings::SetMaxHeaderListSize,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
+  settings->InstanceTemplate()->SetInternalFieldCount(1);
+
+  env->SetAccessor(settings,
+                   "headerTableSize",
+                   Http2Settings::GetHeaderTableSize,
+                   Http2Settings::SetHeaderTableSize);
+  env->SetAccessor(settings,
+                   "enablePush",
+                   Http2Settings::GetEnablePush,
+                   Http2Settings::SetEnablePush);
+  env->SetAccessor(settings,
+                   "maxConcurrentStreams",
+                   Http2Settings::GetMaxConcurrentStreams,
+                   Http2Settings::SetMaxConcurrentStreams);
+  env->SetAccessor(settings,
+                   "initialWindowSize",
+                   Http2Settings::GetInitialWindowSize,
+                   Http2Settings::SetInitialWindowSize);
+  env->SetAccessor(settings,
+                   "maxFrameSize",
+                   Http2Settings::GetMaxFrameSize,
+                   Http2Settings::SetMaxFrameSize);
+  env->SetAccessor(settings,
+                   "maxHeaderListSize",
+                   Http2Settings::GetMaxHeaderListSize,
+                   Http2Settings::SetMaxHeaderListSize);
   env->SetProtoMethod(settings, "setDefaults", Http2Settings::Defaults);
   env->SetProtoMethod(settings, "reset", Http2Settings::Reset);
   env->SetProtoMethod(settings, "pack", Http2Settings::Pack);
@@ -1644,13 +1400,7 @@ void Initialize(Local<Object> target,
       env->NewFunctionTemplate(Http2Headers::New);
   headers->InstanceTemplate()->SetInternalFieldCount(1);
   headers->SetClassName(http2HeadersClassName);
-  headers->InstanceTemplate()->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "size"),
-      Http2Headers::GetSize,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
+  env->SetAccessor(headers, "size", Http2Headers::GetSize);
   env->SetProtoMethod(headers, "add", Http2Headers::Add);
   env->SetProtoMethod(headers, "clear", Http2Headers::Clear);
   env->SetProtoMethod(headers, "reserve", Http2Headers::Reserve);
@@ -1663,118 +1413,22 @@ void Initialize(Local<Object> target,
   Local<FunctionTemplate> t =
       env->NewFunctionTemplate(Http2Session::New);
   t->SetClassName(http2SessionClassName);
-  Local<ObjectTemplate> instance = t->InstanceTemplate();
-  instance->SetInternalFieldCount(1);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "uid"),
-      Http2Session::GetUid,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "wantWrite"),
-      Http2Session::GetWantWrite,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "wantRead"),
-      Http2Session::GetWantRead,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "type"),
-      Http2Session::GetType,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "nextStreamID"),
-      Http2Session::GetNextStreamID,
-      Http2Session::SetNextStreamID,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "effectiveLocalWindowSize"),
-      Http2Session::GetEffectiveLocalWindowSize,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "effectiveRecvDataLength"),
-      Http2Session::GetEffectiveRecvDataLength,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "lastProcStreamID"),
-      Http2Session::GetLastProcStreamID,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "outboundQueueSize"),
-      Http2Session::GetOutboundQueueSize,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "remoteWindowSize"),
-      Http2Session::GetRemoteWindowSize,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "deflateDynamicTableSize"),
-      Http2Session::GetDeflateDynamicTableSize,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "inflateDynamicTableSize"),
-      Http2Session::GetInflateDynamicTableSize,
-      nullptr,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-      FIXED_ONE_BYTE_STRING(isolate, "localWindowSize"),
-      Http2Session::GetLocalWindowSize,
-      Http2Session::SetLocalWindowSize,
-      Local<Value>(),
-      v8::DEFAULT,
-      v8::DontDelete);
-  instance->SetAccessor(
-    FIXED_ONE_BYTE_STRING(isolate, "localSettings"),
-    Http2Session::GetLocalSettings,
-    Http2Session::SetLocalSettings,
-    Local<Value>(),
-    v8::DEFAULT,
-    v8::DontDelete);
-  instance->SetAccessor(
-    FIXED_ONE_BYTE_STRING(isolate, "remoteSettings"),
-    Http2Session::GetRemoteSettings,
-    nullptr,
-    Local<Value>(),
-    v8::DEFAULT,
-    v8::DontDelete);
-
+  t->InstanceTemplate()->SetInternalFieldCount(1);
+  env->SetProtoMethod(t, "reinitialize", Http2Session::Reinitialize);
+  env->SetProtoMethod(t, "close", Http2Session::Close);
+  env->SetProtoMethod(t, "reset", Http2Session::Reset);
+  env->SetProtoMethod(t, "terminate", Http2Session::Terminate);
   env->SetProtoMethod(t, "startGracefulTerminate",
                       Http2Session::GracefulTerminate);
-  env->SetProtoMethod(t, "destroy", Http2Session::Destroy);
-  env->SetProtoMethod(t, "terminate", Http2Session::Terminate);
+  env->SetProtoMethod(t, "request", Http2Session::Request);
+
+  env->SetProtoMethod(t, "getState", Http2Session::GetState);
+  env->SetProtoMethod(t, "setNextStreamID", Http2Session::SetNextStreamID);
+  env->SetProtoMethod(t, "setLocalWindowSize",
+                      Http2Session::SetLocalWindowSize);
+  env->SetProtoMethod(t, "getLocalSettings", Http2Session::GetLocalSettings);
+  env->SetProtoMethod(t, "setLocalSettings", Http2Session::SetLocalSettings);
+  env->SetProtoMethod(t, "getRemoteSettings", Http2Session::GetRemoteSettings);
 
 
   target->Set(context,
@@ -1811,25 +1465,15 @@ void Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, NGHTTP2_HTTP_1_1_REQUIRED);
   NODE_DEFINE_CONSTANT(constants, NGHTTP2_NV_FLAG_NONE);
   NODE_DEFINE_CONSTANT(constants, NGHTTP2_NV_FLAG_NO_INDEX);
-  NODE_DEFINE_CONSTANT(constants, NGHTTP2_NV_FLAG_NO_COPY_NAME);
-  NODE_DEFINE_CONSTANT(constants, NGHTTP2_NV_FLAG_NO_COPY_VALUE);
   NODE_DEFINE_CONSTANT(constants, NGHTTP2_ERR_DEFERRED);
 
-  NODE_DEFINE_STRING_CONSTANT(constants,
-                              "HTTP2_HEADER_STATUS",
-                              HTTP2_HEADER_STATUS);
-  NODE_DEFINE_STRING_CONSTANT(constants,
-                              "HTTP2_HEADER_METHOD",
-                              HTTP2_HEADER_METHOD);
-  NODE_DEFINE_STRING_CONSTANT(constants,
-                              "HTTP2_HEADER_AUTHORITY",
-                              HTTP2_HEADER_AUTHORITY);
-  NODE_DEFINE_STRING_CONSTANT(constants,
-                              "HTTP2_HEADER_SCHEME",
-                              HTTP2_HEADER_SCHEME);
-  NODE_DEFINE_STRING_CONSTANT(constants,
-                              "HTTP2_HEADER_PATH",
-                              HTTP2_HEADER_PATH);
+#define STRING_CONSTANT(N) NODE_DEFINE_STRING_CONSTANT(constants, #N, N)
+  STRING_CONSTANT(HTTP2_HEADER_STATUS);
+  STRING_CONSTANT(HTTP2_HEADER_METHOD);
+  STRING_CONSTANT(HTTP2_HEADER_AUTHORITY);
+  STRING_CONSTANT(HTTP2_HEADER_SCHEME);
+  STRING_CONSTANT(HTTP2_HEADER_PATH);
+#undef STRING_CONSTANT
 
 #define V(name, _) NODE_DEFINE_CONSTANT(constants, HTTP_STATUS_##name);
 HTTP_STATUS_CODES(V)


### PR DESCRIPTION
Next round of updates... this one is pretty significant.

the `Http2Stream` and `Http2Session` objects exposed by `process.binding('http2')` are now `_handle`'s of externally defined `Http2Stream` and `Http2Session` JavaScript objects. FreeList is used to limit creation of new objects and reuse in the same way we reuse http_parser instances.

There are three fundamental performance bottlenecks in this:

* How fast we can read/write data from the socket and pass data to/from the nghttp session instance
* How fast we can process the callbacks invoked by nghttp2, some of which end up requiring us to cross the JS barrier to call into user code
* How fast we can manage the flow of data via the Streams API back into nghttp2

The first two have been fairly well optimized but more can definitely be done. The Streams API implementation definitely needs a lot more work.