### PR TITLE
response.createPushResponse

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -428,6 +428,15 @@ class Http2ServerResponse extends Stream {
     stream.respond(headers);
   }
 
+  createPushResponse(headers, options, callback) {
+    var stream = this[kStream];
+    if (!stream) {
+      callback(new Error('HTTP/2 Stream has been closed'));
+      return;
+    }
+    return stream.pushStream(headers, options, callback);
+  }
+
   [kBeginSend]() {
     var state = this[kState];
     var stream = this[kStream];


### PR DESCRIPTION
As per the [HTTP/2 API documentation](https://github.com/nodejs/http2/blob/master/doc/http2-implementation-notes.md#method-responsecreatepushresponse), the `createPushResponse` method should be exposed on the response object.

It takes the same arguments as `Stream.pushStream`. Not sure if that is the intention?

Fixes #46 