### PR TITLE
Adding request.url for connect compatibility

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -243,6 +243,10 @@ class Http2ServerRequest extends Readable {
     return headers.get(constants.HTTP2_HEADER_SCHEME);
   }
 
+  get url() {
+    return this.path;
+  }
+
   get path() {
     var stream = this[kStream];
     if (!stream) return;

--- a/test/parallel/test-http2-create-client-session.js
+++ b/test/parallel/test-http2-create-client-session.js
@@ -6,8 +6,15 @@ const h2 = require('http2');
 const net = require('net');
 const body =
   '<html><head></head><body><h1>this is some data</h2></body></html>';
+let pathname;
 
-const server = h2.createServer();
+const server = h2.createServer(common.mustCall(requestListener));
+
+function requestListener(request, response) {
+  assert.equal(pathname, request.path);
+  assert.equal(pathname, request.url);
+  assert.equal(pathname, request.headers[':path']);
+}
 
 // we use the lower-level API here
 server.on('stream', common.mustCall(onStream));
@@ -28,12 +35,14 @@ server.on('listening', common.mustCall(function() {
   // TODO mcollina remove on('connect')
   socket.on('connect', function() {
     const client = h2.createClientSession(socket);
+    
+    pathname = `/${Math.random()}`;
 
     const headers = {
       ':method': 'GET',
       ':scheme': 'http',
       ':authority': `localhost:${this.address().port}`,
-      ':path': '/'
+      ':path': pathname
     };
 
     const req = client.request(headers);


### PR DESCRIPTION
Having the `request.url` property aliased to `request.path` fixes a bug with the popular connect framework. Is this acceptable as backwards compatibility or would it be API bloat?