### PR TITLE
Client bug fixes

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -903,7 +903,7 @@ ServerHttp2Stream.prototype[kProceed] = ServerHttp2Stream.prototype.respond;
 class ClientHttp2Stream extends Http2Stream {
   constructor(session, options) {
     super(session, options);
-    this[kState].headerSent = true;
+    this[kState].headersSent = true;
   }
 }
 
@@ -1226,8 +1226,8 @@ function connect(authority, options, listener) {
     throw new TypeError('"authority" must be a string or URL-like object');
 
   const protocol = authority.protocol || options.protocol || 'https:';
-  const port = authority.port !== undefined ? authority.port : 433;
-  const host = authority.hostname || 'localhost';
+  const port = '' + (authority.port !== '' ? authority.port : 443);
+  const host = authority.hostname || authority.host || 'localhost';
 
   let socket;
   switch (protocol) {

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -7,7 +7,7 @@ function isIllegalConnectionSpecificHeader(name, value) {
     case 'http2-settings':
       return true;
     case 'te':
-      return value === 'trailers';
+      return value !== 'trailers';
     default:
       return false;
   }


### PR DESCRIPTION
This PR addresses a few bugs/typos in the client implementation that surfaced while prototyping a gRPC client on top of it:

- Slight modifications in how `host` and `port` are set
- Small typo fixes
- Flipping the legality of setting the `te` header to `trailers`