### PR TITLE
Change stream write loop exit condition in Nghttp2Session::OnStreamRead

### DIFF
--- a/src/node_http2_core.cc
+++ b/src/node_http2_core.cc
@@ -190,7 +190,7 @@ ssize_t Nghttp2Session::OnStreamRead(nghttp2_session* session,
       if (remaining == 0) {
         goto end;
       }
-      
+
       unsigned int n = stream_handle->queue_head_index_;
       // len is the number of bytes in head->bufs[n] that are yet to be written
       size_t len = head->bufs[n].len - stream_handle->queue_head_offset_;

--- a/src/node_http2_core.cc
+++ b/src/node_http2_core.cc
@@ -186,24 +186,25 @@ ssize_t Nghttp2Session::OnStreamRead(nghttp2_session* session,
 
   while (stream_handle->queue_head_ != nullptr) {
     nghttp2_stream_write_queue* head = stream_handle->queue_head_;
-    for (unsigned int n = stream_handle->queue_head_index_;
-         n < head->nbufs; n++) {
-      if (head->bufs[n].len > 0) {
-        size_t len = head->bufs[n].len - stream_handle->queue_head_offset_;
-        len = len < remaining ? len : remaining;
-        memcpy(buf + offset,
-               head->bufs[n].base + stream_handle->queue_head_offset_,
-               len);
-        offset += len;
-        remaining -= len;
-        if (len < head->bufs[n].len) {
-          stream_handle->queue_head_offset_ += len;
-        } else {
-          stream_handle->queue_head_index_++;
-          stream_handle->queue_head_offset_ = 0;
-        }
-      } else {
+    while (stream_handle->queue_head_index_ < head->nbufs) {
+      if (remaining == 0) {
         goto end;
+      }
+      
+      unsigned int n = stream_handle->queue_head_index_;
+      // len is the number of bytes in head->bufs[n] that are yet to be written
+      size_t len = head->bufs[n].len - stream_handle->queue_head_offset_;
+      size_t bytes_to_write = len < remaining ? len : remaining;
+      memcpy(buf + offset,
+             head->bufs[n].base + stream_handle->queue_head_offset_,
+             bytes_to_write);
+      offset += bytes_to_write;
+      remaining -= bytes_to_write;
+      if (bytes_to_write < len) {
+        stream_handle->queue_head_offset_ += bytes_to_write;
+      } else {
+        stream_handle->queue_head_index_++;
+        stream_handle->queue_head_offset_ = 0;
       }
     }
     stream_handle->queue_head_offset_ = 0;

--- a/test/parallel/test-http2-client-window-size.js
+++ b/test/parallel/test-http2-client-window-size.js
@@ -1,0 +1,100 @@
+'use strict';
+
+// This test ensures that servers are able to send data independent of window
+// size.
+
+const assert = require('assert');
+const common = require('../common');
+const h2 = require('http2');
+
+// Given a list of buffers and an initial window size, have a server write
+// each buffer to the HTTP2 Writable stream, and let the client verify that
+// all of the bytes were sent correctly
+function run(buffers, initialWindowSize) {
+  return new Promise((resolve, reject) => {
+    const expectedBuffer = Buffer.concat(buffers);
+
+    const server = h2.createServer();
+    const a = [];
+    server.on('stream', (stream) => {
+      let i = 0;
+      const writeToStream = () => {
+        let cont = () => {
+          i++;
+          if (i < buffers.length) {
+            setImmediate(writeToStream);
+          } else {
+            stream.end();
+          }
+        }
+        const drained = stream.write(buffers[i]);
+        if (drained) {
+          cont();
+        } else {
+          stream.once('drain', writeToStream);
+        }
+      }
+      writeToStream();
+    });
+    server.listen(0);
+
+    server.on('listening', common.mustCall(function() {
+      const port = this.address().port;
+
+      const client =
+        h2.connect({
+          authority: 'localhost',
+          protocol: 'http:',
+          port
+        }, {
+          settings: {
+            initialWindowSize
+          }
+        }).on('connect', common.mustCall(() => {
+          const req = client.request({
+            ':method': 'GET',
+            ':path': '/'
+          });
+          let responses = [];
+          req.on('data', data => {
+            responses.push(data);
+          });
+          req.on('end', common.mustCall(() => {
+            const actualBuffer = Buffer.concat(responses);
+            assert.strictEqual(Buffer.compare(actualBuffer, expectedBuffer), 0);
+            // shut down
+            client.socket.destroy();
+            server.close(() => {
+              resolve();
+            });
+          }));
+          req.end();
+        }));
+    }));
+  });
+}
+
+const bufferValueRange = [0, 1, 2, 3];
+const buffersList = [
+  bufferValueRange.map(a => Buffer.alloc(1 << 4, a)),
+  bufferValueRange.map(a => Buffer.alloc((1 << 8) - 1, a)),
+  bufferValueRange.map(a => Buffer.alloc(1 << 8, a)),
+  bufferValueRange.map(a => Buffer.alloc(1 << 17, a))
+];
+const initialWindowSizeList = [
+  1 << 4,
+  (1 << 8) - 1,
+  1 << 8,
+  1 << 17,
+  undefined // use default window size which is (1 << 16) - 1
+];
+
+// Call `run` on each element in the cartesian product of buffersList and
+// initialWindowSizeList.
+let p = Promise.resolve();
+for (const buffers of buffersList) {
+  for (const initialWindowSize of initialWindowSizeList) {
+    p = p.then(() => run(buffers, initialWindowSize));
+  }
+}
+p.then(common.mustCall(() => {}));

--- a/test/parallel/test-http2-window-size.js
+++ b/test/parallel/test-http2-window-size.js
@@ -15,25 +15,24 @@ function run(buffers, initialWindowSize) {
     const expectedBuffer = Buffer.concat(buffers);
 
     const server = h2.createServer();
-    const a = [];
     server.on('stream', (stream) => {
       let i = 0;
       const writeToStream = () => {
-        let cont = () => {
+        const cont = () => {
           i++;
           if (i < buffers.length) {
             setImmediate(writeToStream);
           } else {
             stream.end();
           }
-        }
+        };
         const drained = stream.write(buffers[i]);
         if (drained) {
           cont();
         } else {
-          stream.once('drain', writeToStream);
+          stream.once('drain', cont);
         }
-      }
+      };
       writeToStream();
     });
     server.listen(0);
@@ -55,8 +54,8 @@ function run(buffers, initialWindowSize) {
             ':method': 'GET',
             ':path': '/'
           });
-          let responses = [];
-          req.on('data', data => {
+          const responses = [];
+          req.on('data', (data) => {
             responses.push(data);
           });
           req.on('end', common.mustCall(() => {
@@ -76,10 +75,9 @@ function run(buffers, initialWindowSize) {
 
 const bufferValueRange = [0, 1, 2, 3];
 const buffersList = [
-  bufferValueRange.map(a => Buffer.alloc(1 << 4, a)),
-  bufferValueRange.map(a => Buffer.alloc((1 << 8) - 1, a)),
-  bufferValueRange.map(a => Buffer.alloc(1 << 8, a)),
-  bufferValueRange.map(a => Buffer.alloc(1 << 17, a))
+  bufferValueRange.map((a) => Buffer.alloc(1 << 4, a)),
+  bufferValueRange.map((a) => Buffer.alloc((1 << 8) - 1, a)),
+  bufferValueRange.map((a) => Buffer.alloc(1 << 17, a))
 ];
 const initialWindowSizeList = [
   1 << 4,

--- a/test/parallel/test-http2-window-size.js
+++ b/test/parallel/test-http2-window-size.js
@@ -2,6 +2,8 @@
 
 // This test ensures that servers are able to send data independent of window
 // size.
+// TODO: This test makes large buffer allocations (128KiB) and should be tested
+// on smaller / IoT platforms in case this poses problems for these targets.
 
 const assert = require('assert');
 const common = require('../common');


### PR DESCRIPTION
The loop that writes queued write requests into a buffer in `Nghttp2Session::OnStreamRead` should break when either there is no more data to write, or the buffer fills up. It seems like it didn't do the latter originally. This becomes apparent when multiple buffers of unwritten bytes are queued in a single write request that don't all fit in `buf`: the for loop in lines 190-209 will always exhaustively iterate through all `nbufs` buffers without writing them, and then the outer while loop will move onto the next element in `queue_head_`.

This change makes the loop exit when no more bytes can be written.

I have tested this manually and will upload a test shortly.