### PR TITLE
http2: fix test-http2-binding after round 11

### DIFF
--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -13,7 +13,7 @@ assert(http2.SessionShutdownWrap);
 assert.strictEqual(typeof http2.Http2Session, 'function');
 assert.strictEqual(typeof http2.SessionShutdownWrap, 'function');
 
-const settings = http2.getDefaultSettings({});
+const settings = require('http2').getDefaultSettings();
 assert.strictEqual(settings.headerTableSize, 4096);
 assert.strictEqual(settings.enablePush, true);
 assert.strictEqual(settings.initialWindowSize, 65535);
@@ -25,10 +25,9 @@ assert.strictEqual(http2.nghttp2ErrorString(-517),
 const check = Buffer.from([0x00, 0x01, 0x00, 0x00, 0x10, 0x00, 0x00, 0x04,
                            0x00, 0x00, 0xff, 0xff, 0x00, 0x05, 0x00, 0x00,
                            0x40, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01]);
-const val = http2.packSettings(http2.getDefaultSettings({}));
+const val = http2.packSettings(require('http2').getDefaultSettings());
 assert.deepStrictEqual(val, check);
 
-assert.doesNotThrow(() => assert(require('http2').getDefaultSettings()));
 assert.doesNotThrow(() => {
   assert(Buffer.isBuffer(require('http2').getPackedSettings()));
 });


### PR DESCRIPTION
As titled, there was a broken test.