### PR TITLE
test: assert headers and flags

### DIFF
--- a/test/parallel/test-http2-create-client-session.js
+++ b/test/parallel/test-http2-create-client-session.js
@@ -12,7 +12,11 @@ const count = 10;
 // we use the lower-level API here
 server.on('stream', common.mustCall(onStream, count));
 
-function onStream(stream) {
+function onStream(stream, headers, flags) {
+  assert.strictEqual(headers[':scheme'], 'http');
+  assert.ok(headers[':authority']);
+  assert.strictEqual(headers[':method'], 'GET');
+  assert.strictEqual(flags, 4);
   stream.respond({
     'content-type': 'text/html',
     ':status': 200


### PR DESCRIPTION
Just reading through the code and noticed that the stream event can take
headers and flags. Just adding them for readability and asserting the
values in the headers and flags.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
test