### PR TITLE
http2: fix res.setHeader to update linkedlist APIs

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -36,7 +36,8 @@ function setHeader(list, name, value) {
 function llistToHeaders(list, count) {
   var ret = {};
   while (!linkedList.isEmpty(list)) {
-    var item = linkedList.shift(list);
+    var item = list._idlePrev;
+    linkedList.remove(item);
     var key = item[0];
 
     if (ret[key]) {
@@ -279,8 +280,18 @@ class Http2ServerResponse extends Stream {
     };
     this[kStream] = stream;
     stream[kResponse] = this;
-    this[kHeaders] = linkedList.create();
-    this[kTrailers] = linkedList.create();
+    var headerList = {
+      _idleNext: null,
+      _idlePrev: null,
+    };
+    linkedList.init(headerList);
+    this[kHeaders] = headerList;
+    var trailersList = {
+      _idleNext: null,
+      _idlePrev: null,
+    };
+    linkedList.init(trailersList);
+    this[kHeaders] = trailersList;
     this.writable = true;
     stream.on('drain', onStreamResponseDrain);
     stream.on('error', onStreamResponseError);

--- a/test/parallel/test-http2-server-set-header.js
+++ b/test/parallel/test-http2-server-set-header.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http2 = require('http2');
+const path = require('path');
+const tls = require('tls');
+const net = require('net');
+const fs = require('fs');
+const body =
+  '<html><head></head><body><h1>this is some data</h2></body></html>';
+
+const server = http2.createServer((req, res) => {
+  res.setHeader('foobar', 'baz');
+  res.setHeader('X-POWERED-BY', 'node-test');
+  res.end(body);
+});
+
+server.listen(0, common.mustCall(() => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const headers = { ':path': '/' };
+  const req = client.request(headers);
+  req.setEncoding('utf8');
+  req.on('response', common.mustCall(function(headers) {
+    assert.strictEqual(headers['foobar'], 'baz');
+    assert.strictEqual(headers['x-powered-by'], 'node-test');
+  }));
+
+  let data = '';
+  req.on('data', (d) => data += d);
+  req.on('end', () => {
+    assert.strictEqual(body, data);
+    server.close();
+    client.destroy();
+  });
+  req.end();
+}));
+
+server.on('error', common.mustNotCall());


### PR DESCRIPTION
Fix `res.setHeader` to create some patch for removed linkedlist APIs.
After this commit, linkedlist APIs are changed. https://github.com/nodejs/node/pull/11726

I just check `res.setHeader` API to create some tests.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
http2
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
