### PR TITLE
docs: fix require('http').HTTP2 to require('http2') in note

### DIFF
--- a/doc/http2-implementation-notes.md
+++ b/doc/http2-implementation-notes.md
@@ -40,7 +40,7 @@ boundary crossing that has to occur.
 
 ```js
 const fs = require('fs');
-const http2 = require('http').HTTP2;
+const http2 = require('http2');
 const options = {
   key: fs.readFileSync('test/fixtures/keys/agent2-key.pem'),
   cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem')
@@ -119,7 +119,7 @@ the type of HEADERS frame received. This type is determined by the underlying
 nghttp2 library based on the HTTP/2 stream state.
 
 ```js
-const constants = require('http').HTTP2.constants;
+const constants = require('http2').constants;
 const session = getSessionSomehow();
 const socket = getSocketSomehow();
 session.on('begin-headers', (stream, category) => {


### PR DESCRIPTION
Our documentation has old require statement, I fixed to new `require('http2')` .

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
docs