### PR TITLE
repl: add http2 to built-in libs in REPL

### DIFF
--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -78,9 +78,9 @@ function stripShebang(content) {
 
 const builtinLibs = [
   'assert', 'buffer', 'child_process', 'cluster', 'crypto', 'dgram', 'dns',
-  'domain', 'events', 'fs', 'http', 'https', 'net', 'os', 'path', 'punycode',
-  'querystring', 'readline', 'repl', 'stream', 'string_decoder', 'tls', 'tty',
-  'url', 'util', 'v8', 'vm', 'zlib'
+  'domain', 'events', 'fs', 'http', 'http2', 'https', 'net', 'os', 'path',
+  'punycode', 'querystring', 'readline', 'repl', 'stream', 'string_decoder',
+  'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'
 ];
 
 function addBuiltinLibsToObject(object) {


### PR DESCRIPTION
Fixed: https://github.com/nodejs/http2/issues/82

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2