### PR TITLE
src: avoid init order compiler warning

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -198,8 +198,8 @@ inline Environment::Environment(IsolateData* isolate_data,
 #endif
       handle_cleanup_waiting_(0),
       http_parser_buffer_(nullptr),
-      fs_stats_field_array_(nullptr),
       http2_socket_buffer_(nullptr),
+      fs_stats_field_array_(nullptr),
       context_(context->GetIsolate(), context) {
   // We'll be creating new objects so make sure we've entered the context.
   v8::HandleScope handle_scope(isolate());


### PR DESCRIPTION
Currently when compiling the following error is displayed:
```console
In file included from
/out/Release/obj/gen/node_javascript.cc:6:
../src/env-inl.h:201:7: warning: field 'fs_stats_field_array_' will be
initialized
      after field 'http2_socket_buffer_' [-Wreorder]
      fs_stats_field_array_(nullptr),
      ^
In file included from
/out/Debug/obj/gen/node_javascript.cc:6:
../src/env-inl.h:201:7: warning: field 'fs_stats_field_array_' will be
initialized
      after field 'http2_socket_buffer_' [-Wreorder]
      fs_stats_field_array_(nullptr),
      ^
1 warning generated.
```
This commit changes the order so that the members appear in the same
order in the initializer list.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src