### PR TITLE
src: make Nghttp2Stream a class

### DIFF
--- a/src/node-http2-core.h
+++ b/src/node-http2-core.h
@@ -239,7 +239,8 @@ class Nghttp2Session {
   friend class Nghttp2Stream;
 };
 
-struct Nghttp2Stream : public std::enable_shared_from_this<Nghttp2Stream> {
+class Nghttp2Stream : public std::enable_shared_from_this<Nghttp2Stream> {
+ public:
   inline ~Nghttp2Stream();
 
   inline int Write(


### PR DESCRIPTION
Currently there is a compiler warning which only showed up after
applying the fix for #85:
```console
In file included from ../src/node-http2-core.cc:1:
../src/node-http2-core.h:242:1: warning: 'Nghttp2Stream' defined as a
struct here but
      previously declared as a class [-Wmismatched-tags]
struct Nghttp2Stream : public
std::enable_shared_from_this<Nghttp2Stream> {
^
../src/node-http2-core.h:19:1: note: did you mean struct here?
class Nghttp2Stream;
^~~~~
struct
In file included from ../src/node-http2-core.cc:1:
```
This commit attempts to fix this warning.

Refs: https://github.com/nodejs/http2/pull/85

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src