### PR TITLE
src: to ToChecked to holder->SetPrototype

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -835,7 +835,7 @@ void Http2Session::OnHeaders(std::shared_ptr<Nghttp2Stream> stream,
   Isolate* isolate = env()->isolate();
   HandleScope scope(isolate);
   Local<Object> holder = Object::New(isolate);
-  holder->SetPrototype(context, v8::Null(isolate));
+  holder->SetPrototype(context, v8::Null(isolate)).ToChecked();
   Local<String> name_str;
   Local<String> value_str;
   Local<Array> array;


### PR DESCRIPTION
Currently the following compiler warning is displayed:
```console
 /out/Debug/obj.target/node/src/node_http2.o
../src/node_http2.cc
../src/node_http2.cc:../src/node_http2.cc838::8383::3 : warning:
warning: ignoring return value of function declared with
      warn_unused_result ignoringattribute  return[-Wunused-result]
value
 of function declared with
      warn_unused_result attribute [-Wunused-result]
  holder->SetPrototype(context, v8::Null(isolate));
  ^~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
This commit adds a check to avoid this warning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src