### PR TITLE
test: check http2 client priority

### DIFF
--- a/test/parallel/test-http2-client-set-priority.js
+++ b/test/parallel/test-http2-client-set-priority.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http2 = require('http2');
+
+const checkWeight = (actual, expect) => {
+  const server = http2.createServer();
+  server.on('stream', common.mustCall((stream, headers, flags) => {
+    assert.strictEqual(stream.state.weight, expect);
+    stream.respond({
+      'content-type': 'text/html',
+      ':status': 200
+    });
+    stream.end('test');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const client = http2.connect(`http://localhost:${port}`);
+
+    const headers = { ':path': '/' };
+    const req = client.request(headers, { weight: actual });
+
+    req.on('data', common.mustCall(() => {}));
+    req.on('end', common.mustCall(() => {
+      server.close();
+      client.destroy();
+    }));
+    req.end();
+  }));
+};
+
+// when client weight is lower than 1, weight is 1
+checkWeight(-1, 1);
+checkWeight(0, 1);
+
+// 1 - 256 is correct weight
+checkWeight(1, 1);
+checkWeight(16, 16);
+checkWeight(256, 256);
+
+// when client weight is higher than 256, weight is 256
+checkWeight(257, 256);
+checkWeight(512, 256);
+
+// when client weight is undefined, weight is default 16
+checkWeight(undefined, 16);


### PR DESCRIPTION
Add tests for priority, I think I should use parent and exclusive in this test, but I have not tested yet, just test weight only.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test