### PR TITLE
src: remove unused MIN/MAX macros

### DIFF
--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -198,9 +198,6 @@ enum padding_strategy_type {
   PADDING_STRATEGY_CALLBACK
 };
 
-#define MIN(A, B) (A < B ? A : B)
-#define MAX(A, B) (A > B ? A : B)
-
 #define DATA_FLAGS(V)                                                         \
   V(ENDSTREAM)                                                                \
   V(ENDDATA)                                                                  \


### PR DESCRIPTION
I cannot find any usage of these macros and it build and all tests pass
locally without them.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src