### PR TITLE
http2: add server push event for client

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -105,6 +105,14 @@ function onSessionHeaders(id, cat, flags, headers) {
     return;
   }
 
+  if (cat === NGHTTP2_HCAT_PUSH_RESPONSE) {
+    if (stream === undefined) {
+      stream = new ClientHttp2Stream(owner, { });
+      streams.set(id, stream);
+    }
+    owner.emit('push', stream, headers, flags);
+  }
+
   let event;
   switch (cat) {
     case NGHTTP2_HCAT_RESPONSE:
@@ -149,7 +157,9 @@ function onSessionStreamClose(id, code) {
   const state = owner[kState];
   const streams = state.streams;
   const stream = streams.get(id);
-  assert(stream, 'Internal HTTP/2 Failure. Stream does not exist.');
+  const alreadyClosed = stream === undefined;
+  if (alreadyClosed)
+    return;
   timers._unrefActive(this); // Unref the session timer
   timers._unrefActive(stream); // Unref the stream timer
   // Notify the stream that it has been closed.

--- a/test/parallel/test-http2-server-push-stream.js
+++ b/test/parallel/test-http2-server-push-stream.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream, headers, flags) => {
+  const port = server.address().port;
+  if (headers[':path'] === '/') {
+    stream.pushStream({
+      ':scheme': 'http',
+      ':path': '/foobar',
+      ':authority': `localhost:${port}`,
+    }, (stream, headers) => {
+      stream.respond({
+        'content-type': 'text/html',
+        ':status': 200,
+        'x-push-data': 'pushed by server',
+      });
+      stream.end('pushed by server data');
+    });
+  }
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+  stream.end('test');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const headers = { ':path': '/' };
+  const client = http2.connect(`http://localhost:${port}`);
+  const req = client.request(headers);
+
+  client.on('push', common.mustCall((stream, headers, flag) => {
+    assert.strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers['content-type'], 'text/html');
+    assert.strictEqual(headers['x-push-data'], 'pushed by server');
+  }));
+
+  let data = '';
+
+  req.on('data', common.mustCall((d) => data += d));
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(data, 'test');
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+}));


### PR DESCRIPTION
http2 server push does not throw any event for clients, and if we use pushStream method, stream can not be found, so throw NPE.

this pull request emit `push` event for client and avoid the NPE. 

 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2, test