### PR TITLE
http2: fix lint errors

### DIFF
--- a/src/node_http2_core.h
+++ b/src/node_http2_core.h
@@ -237,7 +237,7 @@ class Nghttp2Session {
   friend class Nghttp2Stream;
 };
 
-class Nghttp2Stream : public std::enable_shared_from_this<Nghttp2Stream> { 
+class Nghttp2Stream : public std::enable_shared_from_this<Nghttp2Stream> {
  public:
   inline ~Nghttp2Stream();
 

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -6,15 +6,14 @@ const path = require('path');
 const fs = require('fs');
 const tls = require('tls');
 const h2 = require('http2');
-const body =
-  '<html><head></head><body><h1>this is some data</h2></body></html>';
 
 const key = loadKey('agent8-key.pem');
 const cert = loadKey('agent8-cert.pem');
 const ca = loadKey('fake-startcom-root-cert.pem');
 
 function loadKey(keyname) {
-  return fs.readFileSync(path.join(common.fixturesDir, 'keys', keyname), 'binary');
+  return fs.readFileSync(
+    path.join(common.fixturesDir, 'keys', keyname), 'binary');
 }
 
 const server = h2.createSecureServer({cert, key});
@@ -47,7 +46,7 @@ server.on('listening', common.mustCall(function() {
     req.on('response', common.mustCall(function(headers) {
       assert.strictEqual(headers[':status'], '200', 'status code is set');
       assert.strictEqual(headers['content-type'], 'text/html',
-                        'content type is set');
+                         'content type is set');
       assert(headers['date'], 'there is a date');
     }));
 

--- a/test/parallel/test-http2-server-set-header.js
+++ b/test/parallel/test-http2-server-set-header.js
@@ -3,10 +3,6 @@
 const common = require('../common');
 const assert = require('assert');
 const http2 = require('http2');
-const path = require('path');
-const tls = require('tls');
-const net = require('net');
-const fs = require('fs');
 const body =
   '<html><head></head><body><h1>this is some data</h2></body></html>';
 


### PR DESCRIPTION
I found some lint errors,

```
./node tools/eslint/bin/eslint.js --cache --rulesdir=tools/eslint-rules --ext=.js,.md \
	  benchmark doc lib test tools

/Users/yosuke/Program/http2/test/parallel/test-http2-create-client-secure-session.js
   9:7   error  'body' is assigned a value but never used       no-unused-vars
  17:1   error  Line 17 exceeds the maximum line length of 80   max-len
  50:25  error  Expected indentation of 25 spaces but found 24  indent

/Users/yosuke/Program/http2/test/parallel/test-http2-server-set-header.js
  6:7  error  'path' is assigned a value but never used  no-unused-vars
  7:7  error  'tls' is assigned a value but never used   no-unused-vars
  8:7  error  'net' is assigned a value but never used   no-unused-vars
  9:7  error  'fs' is assigned a value but never used    no-unused-vars

✖ 7 problems (7 errors, 0 warnings)

make[2]: *** [jslint] Error 1
Running C++ linter...
src/node_http2_core.h:240:  Line ends in whitespace.  Consider deleting these extra spaces.  [whitespace/end_of_line] [4]
Total errors found: 1
make[2]: *** [cpplint] Error 1
make[1]: *** [lint] Error 2
make: *** [test] Error 2
```

This PR fixed the errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2