### PR TITLE
src: improve readability of CopyHeaders

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -57,18 +57,19 @@ inline void CopyHeaders(Isolate* isolate,
     CHECK(value->IsString());
     size_t keylen = StringBytes::StorageSize(isolate, key, ASCII);
     size_t valuelen = StringBytes::StorageSize(isolate, value, ASCII);
-    (*list)[n].flags = NGHTTP2_NV_FLAG_NONE;
+    nghttp2_nv nv = (*list)[n];
+    nv.flags = NGHTTP2_NV_FLAG_NONE;
     if (header->Get(2)->BooleanValue())
-      (*list)[n].flags |= NGHTTP2_NV_FLAG_NO_INDEX;
-    (*list)[n].name = Malloc<uint8_t>(keylen);
-    (*list)[n].value = Malloc<uint8_t>(valuelen);
-    (*list)[n].namelen =
+      nv.flags |= NGHTTP2_NV_FLAG_NO_INDEX;
+    nv.name = Malloc<uint8_t>(keylen);
+    nv.value = Malloc<uint8_t>(valuelen);
+    nv.namelen =
         StringBytes::Write(isolate,
-                           reinterpret_cast<char*>((*list)[n].name),
+                           reinterpret_cast<char*>(nv.name),
                            keylen, key, ASCII);
-    (*list)[n].valuelen =
+    nv.valuelen =
         StringBytes::Write(isolate,
-                           reinterpret_cast<char*>((*list)[n].value),
+                           reinterpret_cast<char*>(nv.value),
                            valuelen, value, ASCII);
   }
 }

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -57,7 +57,7 @@ inline void CopyHeaders(Isolate* isolate,
     CHECK(value->IsString());
     size_t keylen = StringBytes::StorageSize(isolate, key, ASCII);
     size_t valuelen = StringBytes::StorageSize(isolate, value, ASCII);
-    nghttp2_nv nv = (*list)[n];
+    nghttp2_nv& nv = (*list)[n];
     nv.flags = NGHTTP2_NV_FLAG_NONE;
     if (header->Get(2)->BooleanValue())
       nv.flags |= NGHTTP2_NV_FLAG_NO_INDEX;


### PR DESCRIPTION
This commit attempts to make the CopyHeaders function a little more
readable (hopefully). Instread of dereferencing the list of name value
pointer multiple times only do it once and store it in a local variable.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src