### PR TITLE
src: add assertion to check cb is not null

### DIFF
--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -73,6 +73,7 @@ void Nghttp2Session::QueuePendingCallback(nghttp2_pending_cb_list* item) {
 }
 
 inline void nghttp2_free_headers_list(nghttp2_pending_headers_cb* cb) {
+  assert(cb != nullptr);
   while (cb->headers != nullptr) {
     nghttp2_header_list* item = cb->headers;
     nghttp2_rcbuf_decref(item->value);


### PR DESCRIPTION
Currently nghttp2_free_headers_list uses the cb pointer but does not
check it for null first like other functions do. Wanted to bring this up
just in case it was simply overlooked.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
src