### PR TITLE
http2: add priority advisement event

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -234,6 +234,24 @@ function onSettings() {
   owner[kRemoteSettings] = undefined;
 }
 
+// If the stream exists, an attempt will be made to emit an event
+// on the stream object itself. Otherwise, forward it on to the
+// session (which may, in turn, forward it on to the server)
+function onPriority(id, parent, weight, exclusive) {
+  debug(`priority advisement for stream ${id}: \n` +
+        `  parent: ${parent},\n  weight: ${weight},\n` +
+        `  exclusive: ${exclusive}`);
+  timers._unrefActive(this);
+  const owner = this[kOwner];
+  const state = owner[kState];
+  const streams = state.streams;
+  const stream = streams.get(id);
+  if (stream === undefined ||
+      !stream.emit('priority', parent, weight, exclusive)) {
+    owner.emit('priority', id, parent, weight, exclusive);
+  }
+}
+
 // Called when a requested session shutdown has been completed.
 function onSessionShutdownComplete(status, wrap) {
   if (wrap && typeof wrap.callback === 'function')
@@ -365,6 +383,7 @@ function setupHandle(session, socket, type, options, settings) {
     const handle = new binding.Http2Session(type, options);
     handle[kOwner] = session;
     session[kHandle] = handle;
+    handle.onpriority = onPriority;
     handle.onsettings = onSettings;
     handle.onheaders = onSessionHeaders;
     handle.ontrailers = onSessionTrailers;
@@ -1201,6 +1220,11 @@ function sessionOnSelectPadding(frameLen, maxPayloadLen, ret) {
   }
 }
 
+function sessionOnPriority(stream, parent, weight, exclusive) {
+  const server = this[kServer];
+  server.emit('priority', stream, parent, weight, exclusive);
+}
+
 function connectionListener(socket) {
   const options = this[kOptions] || {};
 
@@ -1227,6 +1251,7 @@ function connectionListener(socket) {
   session.on('error', sessionOnError);
   session.on('stream', sessionOnStream);
   session.on('selectPadding', sessionOnSelectPadding);
+  session.on('priority', sessionOnPriority);
 
   session[kServer] = this;
   socket[kServer] = this;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -934,6 +934,12 @@ class Http2Stream extends Duplex {
     this.rstStream(NGHTTP2_INTERNAL_ERROR);
   }
 
+  // Note that this (and other methods like sendHeaders and rstStream) cause
+  // nghttp to queue frames up in its internal buffer that are not actually
+  // sent on the wire until the next tick of the event loop. The semantics of
+  // this method then are: queue a priority frame to be sent and not immediately
+  // send the priority frame. There is current no callback triggered when the
+  // data is actually sent.
   priority(options) {
     if (this.id === undefined) {
       this.once('connect', () => this.priority(options));

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -907,6 +907,30 @@ void Http2Session::OnSettings() {
   }
 }
 
+void Http2Session::OnPriority(int32_t stream,
+                              int32_t parent,
+                              int32_t weight,
+                              int8_t exclusive) {
+  Local<Context> context = env()->context();
+  Isolate* isolate = env()->isolate();
+  HandleScope scope(isolate);
+  Local<String> onpriority = FIXED_ONE_BYTE_STRING(isolate, "onpriority");
+  if (object()->Has(context, onpriority).FromJust()) {
+    v8::TryCatch try_catch(isolate);
+    Local<Value> argv[4] = {
+      Integer::New(isolate, stream),
+      Integer::New(isolate, parent),
+      Integer::New(isolate, weight),
+      Boolean::New(isolate, exclusive)
+    };
+    Local<Value> ret = MakeCallback(onpriority, arraysize(argv), argv);
+    if (ret.IsEmpty()) {
+      ClearFatalExceptionHandlers(env());
+      FatalException(isolate, try_catch);
+    }
+  }
+}
+
 void Http2Session::OnStreamAllocImpl(size_t suggested_size,
                                       uv_buf_t* buf,
                                       void* ctx) {

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -396,6 +396,10 @@ class Http2Session : public AsyncWrap,
   void OnDataChunks(std::shared_ptr<Nghttp2Stream> stream,
                     std::shared_ptr<nghttp2_data_chunks_t> chunks) override;
   void OnSettings() override;
+  void OnPriority(int32_t stream,
+                  int32_t parent,
+                  int32_t weight,
+                  int8_t exclusive) override;
   void OnTrailers(std::shared_ptr<Nghttp2Stream> stream,
                   MaybeStackBuffer<nghttp2_nv>* trailers) override;
   uv_buf_t* AllocateSend(size_t recommended) override;

--- a/src/node_http2_core.h
+++ b/src/node_http2_core.h
@@ -69,6 +69,7 @@ typedef enum {
   NGHTTP2_CB_STREAM_CLOSE,
   NGHTTP2_CB_DATA_CHUNKS,
   NGHTTP2_CB_SETTINGS,
+  NGHTTP2_CB_PRIORITY
 } nghttp2_pending_cb_type;
 
 struct nghttp2_pending_settings_cb {};
@@ -84,6 +85,13 @@ struct nghttp2_pending_data_chunks_cb {
 struct nghttp2_pending_session_send_cb {
   size_t length = 0;
   uv_buf_t* buf = nullptr;
+};
+
+struct nghttp2_pending_priority_cb {
+  int32_t stream;
+  int32_t parent;
+  int32_t weight;
+  int8_t exclusive;
 };
 
 struct nghttp2_pending_headers_cb {
@@ -150,6 +158,10 @@ class Nghttp2Session {
   virtual void OnDataChunks(std::shared_ptr<Nghttp2Stream> stream,
                             std::shared_ptr<nghttp2_data_chunks_t> chunks) {}
   virtual void OnSettings() {}
+  virtual void OnPriority(int32_t stream,
+                          int32_t parent,
+                          int32_t weight,
+                          int8_t exclusive) {}
   virtual ssize_t GetPadding(size_t frameLength,
                              size_t maxFrameLength) { return 0; }
   virtual void OnTrailers(std::shared_ptr<Nghttp2Stream> stream,
@@ -172,6 +184,8 @@ class Nghttp2Session {
   inline void DrainDataChunks(nghttp2_pending_data_chunks_cb*,
                               bool freeOnly = false);
   inline void DrainSettings(nghttp2_pending_settings_cb*,
+                            bool freeOnly = false);
+  inline void DrainPriority(nghttp2_pending_priority_cb*,
                             bool freeOnly = false);
 
   // If freeOnly is true, the callbacks will be freed without taking action

--- a/test/parallel/test-http2-priority-event.js
+++ b/test/parallel/test-http2-priority-event.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer();
+
+// we use the lower-level API here
+server.on('stream', common.mustCall(onStream));
+
+function onPriority(stream, parent, weight, exclusive) {
+  assert.strictEqual(stream, 1);
+  assert.strictEqual(parent, 0);
+  assert.strictEqual(weight, 1);
+  assert.strictEqual(exclusive, false);
+}
+
+function onStream(stream, headers, flags) {
+  stream.priority({
+    parent: 0,
+    weight: 1,
+    exclusive: false
+  });
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+  stream.end('hello world');
+}
+
+server.listen(0);
+
+server.on('priority', common.mustCall(onPriority));
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+
+  client.on('priority', common.mustCall(onPriority));
+
+  const req = client.request({ ':path': '/'});
+
+  client.on('connect', () => {
+    req.priority({
+      parent: 0,
+      weight: 1,
+      exclusive: false
+    });
+  });
+
+  req.on('response', common.mustCall());
+  req.on('data', common.noop);
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+
+}));


### PR DESCRIPTION
Trigger a 'priority' event on the session, stream, and server when a priority frame is received.

Refs: https://github.com/nodejs/http2/issues/69

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)

http2