### PR TITLE
http2: fixed .finished property on req/res compat

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -3,9 +3,7 @@
 const Stream = require('stream');
 const Readable = Stream.Readable;
 const binding = process.binding('http2');
-const {
-  isIllegalConnectionSpecificHeader,
-} = require('internal/http2/util');
+const { isIllegalConnectionSpecificHeader } = require('internal/http2/util');
 const constants = binding.constants;
 
 const kFinish = Symbol('finish');
@@ -132,10 +130,6 @@ class Http2ServerRequest extends Readable {
     this.on('pause', onRequestPause);
     this.on('resume', onRequestResume);
     this.on('drain', onRequestDrain);
-  }
-
-  get finished() {
-    return this._readableState.ended;
   }
 
   get closed() {
@@ -267,7 +261,8 @@ class Http2ServerResponse extends Stream {
   }
 
   get finished() {
-    return this._writableState.ended;
+    var stream = this[kStream];
+    return stream === undefined || stream._writableState.ended;
   }
 
   get closed() {

--- a/test/parallel/test-http2-compat-serverresponse-finished.js
+++ b/test/parallel/test-http2-compat-serverresponse-finished.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const h2 = require('http2');
+
+// Http2ServerResponse.finished
+
+const server = h2.createServer();
+server.listen(0, common.mustCall(function() {
+  const port = server.address().port;
+  server.once('request', common.mustCall(function(request, response) {
+    response.stream.on('finish', common.mustCall(function() {
+      server.close();
+    }));
+    assert.strictEqual(response.finished, false);
+    response.end(' ');
+    assert.strictEqual(response.finished, true);
+  }));
+
+  const url = `http://localhost:${port}`;
+  const client = h2.connect(url, common.mustCall(function() {
+    const headers = {
+      ':path': '/',
+      ':method': 'GET',
+      ':scheme': 'http',
+      ':authority': `localhost:${port}`
+    };
+    const request = client.request(headers);
+    request.on('end', common.mustCall(function() {
+      client.destroy();
+    }));
+    request.end();
+    request.resume();
+  }));
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

As per Node.js HTTP API docs:

1. Removed `request.finished` property; and
1. Added and fixed [`response.finished`](https://nodejs.org/api/http.html#http_response_finished) property.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2
