### PR TITLE
http2: writeHead optional statusMessage

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -386,7 +386,12 @@ class Http2ServerResponse extends Stream {
     this.writeHead(statusCode);
   }
 
-  writeHead(statusCode, headers) {
+  // HTTP/2 has no status message support (RFC7540 8.1.2.4), so
+  // statusMessage is ignored and only allowed for backwards compatibility.
+  writeHead(statusCode, statusMessage, headers) {
+    if (headers === undefined && typeof statusMessage === 'object') {
+      headers = statusMessage;
+    }
     var state = this[kState];
     if (state.headersSent === true)
       return;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -389,14 +389,12 @@ class Http2ServerResponse extends Stream {
   }
 
   writeHead(statusCode, statusMessage, headers) {
-    if (typeof statusMessage === 'string') {
-      if (statusMessageWarned === false) {
-        process.emitWarning(
-          'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)',
-          'UnsupportedWarning'
-        );
-        statusMessageWarned = true;
-      }
+    if (typeof statusMessage === 'string' && statusMessageWarned === false) {
+      process.emitWarning(
+        'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)',
+        'UnsupportedWarning'
+      );
+      statusMessageWarned = true;
     }
     if (headers === undefined && typeof statusMessage === 'object') {
       headers = statusMessage;

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -17,6 +17,8 @@ const kResponse = Symbol('response');
 const kHeaders = Symbol('headers');
 const kTrailers = Symbol('trailers');
 
+let statusMessageWarned = false;
+
 // Defines and implements an API compatibility layer on top of the core
 // HTTP/2 implementation, intended to provide an interface that is as
 // close as possible to the current require('http') API
@@ -386,9 +388,16 @@ class Http2ServerResponse extends Stream {
     this.writeHead(statusCode);
   }
 
-  // HTTP/2 has no status message support (RFC7540 8.1.2.4), so
-  // statusMessage is ignored and only allowed for backwards compatibility.
   writeHead(statusCode, statusMessage, headers) {
+    if (typeof statusMessage === 'string') {
+      if (statusMessageWarned === false) {
+        process.emitWarning(
+          'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)',
+          'UnsupportedWarning'
+        );
+        statusMessageWarned = true;
+      }
+    }
     if (headers === undefined && typeof statusMessage === 'object') {
       headers = statusMessage;
     }

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -6,6 +6,14 @@ const h2 = require('http2');
 
 // Http2ServerResponse.writeHead should accept an optional status message
 
+const unsupportedWarned = common.mustCall(1);
+process.on('warning', ({name, message}) => {
+  const expectedMessage =
+    'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)';
+  if (name === 'UnsupportedWarning' && message === expectedMessage)
+    unsupportedWarned();
+});
+
 const server = h2.createServer();
 server.listen(0, common.mustCall(function() {
   const port = server.address().port;
@@ -13,10 +21,6 @@ server.listen(0, common.mustCall(function() {
     const statusCode = 200;
     const statusMessage = 'OK';
     const headers = {'foo-bar': 'abc123'};
-    common.expectWarning(
-      'UnsupportedWarning',
-      'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)'
-    );
     response.writeHead(statusCode, statusMessage, headers);
 
     response.stream.on('finish', common.mustCall(function() {

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const h2 = require('http2');
+
+// Http2ServerResponse.writeHead should accept an optional status message
+
+const server = h2.createServer();
+server.listen(0, common.mustCall(function() {
+  const port = server.address().port;
+  server.once('request', common.mustCall(function(request, response) {
+    const statusCode = 200;
+    const statusMessage = 'OK';
+    const headers = {'foo-bar': 'abc123'};
+    response.writeHead(statusCode, statusMessage, headers);
+
+    response.stream.on('finish', common.mustCall(function() {
+      server.close();
+    }));
+    response.end(' ');
+  }));
+
+  const url = `http://localhost:${port}`;
+  const client = h2.connect(url, common.mustCall(function() {
+    const headers = {
+      ':path': '/',
+      ':method': 'GET',
+      ':scheme': 'http',
+      ':authority': `localhost:${port}`
+    };
+    const request = client.request(headers);
+    request.on('response', common.mustCall(function(headers) {
+      assert.strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers['foo-bar'], 'abc123');
+    }, 1));
+    request.on('end', common.mustCall(function() {
+      client.destroy();
+    }));
+    request.end();
+    request.resume();
+  }));
+}));

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -13,6 +13,10 @@ server.listen(0, common.mustCall(function() {
     const statusCode = 200;
     const statusMessage = 'OK';
     const headers = {'foo-bar': 'abc123'};
+    common.expectWarning(
+      'UnsupportedWarning',
+      'Status message is not supported by HTTP/2 (RFC7540 8.1.2.4)'
+    );
     response.writeHead(statusCode, statusMessage, headers);
 
     response.stream.on('finish', common.mustCall(function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Adds backwards compatible support for the optional `statusMessage` argument to [`response.writeHead`](https://nodejs.org/api/http.html#http_response_writehead_statuscode_statusmessage_headers).

The status message is [not used in HTTP/2](http://httpwg.org/specs/rfc7540.html#HttpResponse). This optional argument is only exposed to stay synched with the `require('http')` API.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2