### PR TITLE
http2: ensure informational headers work

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -91,7 +91,7 @@ E('ERR_HTTP2_HEADER_REQUIRED',
   (name) => `The ${name} header is required`);
 E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.');
 E('ERR_HTTP2_HEADERS_AFTER_RESPOND',
-  'Cannot specify HTTP status header after response initiated');
+  'Cannot specify additional headers after response initiated');
 E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
   'HTTP/1 Connection specific headers are forbidden');
 E('ERR_HTTP2_INVALID_INFO_STATUS',

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -183,18 +183,32 @@ function onSessionHeaders(id, cat, flags, headers) {
     owner.emit('stream', stream, headers, flags);
   } else {
     let event;
+    let status;
     switch (cat) {
       case NGHTTP2_HCAT_REQUEST:
         event = 'request';
         break;
       case NGHTTP2_HCAT_RESPONSE:
-        event = 'response';
+        status = headers[HTTP2_HEADER_STATUS];
+        if (!endOfStream &&
+            status !== undefined &&
+            status >= 100 &&
+            status < 200) {
+          event = 'headers';
+        } else {
+          event = 'response';
+        }
         break;
       case NGHTTP2_HCAT_PUSH_RESPONSE:
         event = 'push';
         break;
       case NGHTTP2_HCAT_HEADERS:
-        event = endOfStream ? 'trailers' : 'headers';
+        status = headers[HTTP2_HEADER_STATUS];
+        if (!endOfStream && status !== undefined && status >= 200) {
+          event = 'response';
+        } else {
+          event = endOfStream ? 'trailers' : 'headers';
+        }
         break;
       default:
         assert.fail(null, null,
@@ -1007,40 +1021,6 @@ class Http2Stream extends Duplex {
     const session = this[kSession];
     session.priority(this, options);
   }
-
-  // Sends a block of informational headers. In theory, the HTTP/2 spec
-  // allows sending a HEADER block at any time during a streams lifecycle,
-  // but the HTTP request/response semantics defined in HTTP/2 places limits
-  // such that HEADERS may only be sent *before* or *after* DATA frames.
-  // If the block of headers being sent includes a status code, it MUST be
-  // a 1xx informational code and it MUST be sent before the request/response
-  // headers are sent, or an error will be thrown.
-  additionalHeaders(headers) {
-    if (this.id === undefined) {
-      this.once('connect', () => this.additionalHeaders(headers));
-      return;
-    }
-    timers._unrefActive(this);
-    const state = this[kState];
-    const session = this[kSession];
-    const handle = session[kHandle];
-
-    assertIsObject(headers, 'headers');
-    headers = Object.assign(Object.create(null), headers);
-    if (headers[HTTP2_HEADER_STATUS] != null) {
-      if (state.headersSent) {
-        throw new errors.Error('ERR_HTTP2_HEADERS_AFTER_RESPOND');
-      }
-      const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
-      if (statusCode === HTTP_STATUS_SWITCHING_PROTOCOLS)
-        throw new errors.Error('ERR_HTTP2_STATUS_101');
-      if (statusCode < 100 || statusCode >= 200)
-        throw new errors.RangeError('ERR_HTTP2_INVALID_INFO_STATUS');
-    }
-
-    emitErrorIfNecessary(this,
-                         handle.sendHeaders(this.id, mapToHeaders(headers)));
-  }
 }
 
 class ServerHttp2Stream extends Http2Stream {
@@ -1135,6 +1115,42 @@ class ServerHttp2Stream extends Http2Stream {
       handle.submitResponse(this.id,
                             mapToHeaders(headers),
                             options.endStream));
+  }
+
+  // Sends a block of informational headers. In theory, the HTTP/2 spec
+  // allows sending a HEADER block at any time during a streams lifecycle,
+  // but the HTTP request/response semantics defined in HTTP/2 places limits
+  // such that HEADERS may only be sent *before* or *after* DATA frames.
+  // If the block of headers being sent includes a status code, it MUST be
+  // a 1xx informational code and it MUST be sent before the request/response
+  // headers are sent, or an error will be thrown.
+  additionalHeaders(headers) {
+    if (this.id === undefined) {
+      this.once('connect', () => this.additionalHeaders(headers));
+      return;
+    }
+
+    const state = this[kState];
+    const session = this[kSession];
+    const handle = session[kHandle];
+
+    if (state.headersSent) {
+      throw new errors.Error('ERR_HTTP2_HEADERS_AFTER_RESPOND');
+    }
+
+    assertIsObject(headers, 'headers');
+    headers = Object.assign(Object.create(null), headers);
+    if (headers[HTTP2_HEADER_STATUS] != null) {
+      const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
+      if (statusCode === HTTP_STATUS_SWITCHING_PROTOCOLS)
+        throw new errors.Error('ERR_HTTP2_STATUS_101');
+      if (statusCode < 100 || statusCode >= 200)
+        throw new errors.RangeError('ERR_HTTP2_INVALID_INFO_STATUS');
+    }
+
+    timers._unrefActive(this);
+    emitErrorIfNecessary(this,
+                         handle.sendHeaders(this.id, mapToHeaders(headers)));
   }
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -444,7 +444,7 @@ function setupHandle(session, socket, type, options, settings) {
     handle.onread = onSessionRead;
     handle.ongetpadding = onSelectPadding;
     handle.consume(socket._handle._externalStream);
-    session.submitSettings(settings);
+    session.settings(settings);
     const state = session[kState];
     state.connecting = false;
     session.emit('connect', session, socket);
@@ -577,7 +577,7 @@ class Http2Session extends EventEmitter {
     return settings;
   }
 
-  submitSettings(settings) {
+  settings(settings) {
     timers._unrefActive(this);
     const handle = this[kHandle];
     assertIsObject(settings, 'settings');
@@ -586,7 +586,7 @@ class Http2Session extends EventEmitter {
     emitErrorIfNecessary(this, handle.submitSettings(settings));
   }
 
-  submitPriority(stream, options) {
+  priority(stream, options) {
     timers._unrefActive(this);
     const handle = this[kHandle];
     if (!(stream instanceof Http2Stream)) {
@@ -992,12 +992,12 @@ class Http2Stream extends Duplex {
     this.rstStream(NGHTTP2_INTERNAL_ERROR);
   }
 
-  // Note that this (and other methods like sendHeaders and rstStream) cause
-  // nghttp to queue frames up in its internal buffer that are not actually
-  // sent on the wire until the next tick of the event loop. The semantics of
-  // this method then are: queue a priority frame to be sent and not immediately
-  // send the priority frame. There is current no callback triggered when the
-  // data is actually sent.
+  // Note that this (and other methods like additionalHeaders and rstStream)
+  // cause nghttp to queue frames up in its internal buffer that are not
+  // actually sent on the wire until the next tick of the event loop. The
+  // semantics of this method then are: queue a priority frame to be sent and
+  // not immediately send the priority frame. There is current no callback
+  // triggered when the data is actually sent.
   priority(options) {
     if (this.id === undefined) {
       this.once('connect', () => this.priority(options));
@@ -1005,13 +1005,19 @@ class Http2Stream extends Duplex {
     }
     timers._unrefActive(this);
     const session = this[kSession];
-    session.submitPriority(this, options);
+    session.priority(this, options);
   }
 
-  // Sends a block of headers.
-  sendHeaders(headers) {
+  // Sends a block of informational headers. In theory, the HTTP/2 spec
+  // allows sending a HEADER block at any time during a streams lifecycle,
+  // but the HTTP request/response semantics defined in HTTP/2 places limits
+  // such that HEADERS may only be sent *before* or *after* DATA frames.
+  // If the block of headers being sent includes a status code, it MUST be
+  // a 1xx informational code and it MUST be sent before the request/response
+  // headers are sent, or an error will be thrown.
+  additionalHeaders(headers) {
     if (this.id === undefined) {
-      this.once('connect', () => this.sendHeaders(headers));
+      this.once('connect', () => this.additionalHeaders(headers));
       return;
     }
     timers._unrefActive(this);

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer();
+
+// we use the lower-level API here
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+
+  assert.throws(() => stream.additionalHeaders({ ':status': 201 }),
+                common.expectsError({
+                  code: 'ERR_HTTP2_INVALID_INFO_STATUS',
+                  type: RangeError,
+                  message: /^Invalid informational status code$/
+                }));
+
+  assert.throws(() => stream.additionalHeaders({ ':status': 101 }),
+                common.expectsError({
+                  code: 'ERR_HTTP2_STATUS_101',
+                  type: Error,
+                  message: /^HTTP status code 101 \(Switching Protocols\) is forbidden in HTTP\/2$/
+                }));
+
+  // Can send more than one
+  stream.additionalHeaders({ ':status': 100 });
+  stream.additionalHeaders({ ':status': 100 });
+
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+
+  assert.throws(() => stream.additionalHeaders({ abc: 123 }),
+                common.expectsError({
+                  code: 'ERR_HTTP2_HEADERS_AFTER_RESPOND',
+                  type: Error,
+                  message: /^Cannot specify additional headers after response initiated$/
+                }));
+
+  stream.end('hello world');
+}
+
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request({ ':path': '/'});
+
+  // The additionalHeaders method does not exist on client stream
+  assert.strictEqual(req.additionalHeaders, undefined);
+
+  // Additional informational headers
+  req.on('headers', common.mustCall((headers) => {
+    assert.notStrictEqual(headers, undefined);
+    assert.strictEqual(headers[':status'], '100');
+  }, 2));
+
+  // Response headers
+  req.on('response', common.mustCall((headers) => {
+    assert.notStrictEqual(headers, undefined);
+    assert.strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers['content-type'], 'text/html');
+  }));
+
+  req.resume();
+
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+
+}));


### PR DESCRIPTION
* Rename a couple of APIs for simplicity
* Ensure that informational headers (1xx status headers) work properly.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
http2