### PR TITLE
http2: fix multivalued headers and cookies

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -92,8 +92,12 @@ E('ERR_HTTP2_HEADER_REQUIRED',
 E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.');
 E('ERR_HTTP2_HEADERS_AFTER_RESPOND',
   'Cannot specify HTTP status header after response initiated');
+E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
+  'HTTP/1 Connection specific headers are forbidden');
 E('ERR_HTTP2_INVALID_INFO_STATUS',
   'Invalid informational status code');
+E('ERR_HTTP2_PSEUDO_HEADERS_SINGLE_VALUE',
+  'HTTP/2 pseudo-headers must have a single value');
 E('ERR_HTTP2_SOCKET_BOUND',
   'The socket is already bound to an Http2Session');
 E('ERR_HTTP2_STATUS_101',

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -66,6 +66,7 @@ const {
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_SCHEME,
   HTTP2_HEADER_STATUS,
+  HTTP2_HEADER_COOKIE,
 
   HTTP_STATUS_CONTENT_RESET,
   HTTP_STATUS_OK,
@@ -155,6 +156,15 @@ function onSessionHeaders(id, cat, flags, headers) {
 
   const endOfStream = !!(flags & NGHTTP2_FLAG_END_STREAM);
   let stream = streams.get(id);
+
+  // https://tools.ietf.org/html/rfc7540#section-8.1.2.5
+  // "...If there are multiple Cookie header fields after decompression,
+  //  these MUST be concatenated into a single octet string using the
+  //  two-octet delimiter of 0x3B, 0x20 (the ASCII string "; ") before being
+  //  passed into a non-HTTP/2 context."
+  if (Array.isArray(headers[HTTP2_HEADER_COOKIE]))
+    headers[HTTP2_HEADER_COOKIE] =
+      headers[HTTP2_HEADER_COOKIE].join('; ');
 
   if (stream === undefined) {
     switch (owner.type) {

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const errors = require('internal/errors');
+
 function isIllegalConnectionSpecificHeader(name, value) {
   switch (name) {
     case 'connection':
@@ -15,61 +17,46 @@ function isIllegalConnectionSpecificHeader(name, value) {
 
 function assertIllegalConnectionSpecificHeader(name, value, ctor) {
   if (isIllegalConnectionSpecificHeader(name, value)) {
-    var err = new Error('HTTP/1 Connection specific headers are forbidden');
+    var err = new errors.Error('ERR_HTTP2_INVALID_CONNECTION_HEADERS');
     Error.captureStackTrace(err, ctor);
     throw err;
   }
 }
 
-function assertEmptyHeaderName(name) {
-  if (name.length === 0) {
-    var err = new Error('HTTP header names must not be empty strings');
-    Error.captureStackTrace(err, assertEmptyHeaderName);
-    throw err;
-  }
-}
-
 function mapToHeaders(map) {
+  var ret = [];
   var keys = Object.keys(map);
-  var size = keys.length;
   for (var i = 0; i < keys.length; i++) {
-    if (Array.isArray(keys[i])) {
-      size += keys[i].length - 1;
-    }
-  }
-  var ret = Array(size);
-  var c = 0;
-  var val;
-
-  for (i = 0; i < keys.length; i++) {
-    var key = String(keys[i]);
+    var key = keys[i];
     var value = map[key];
-    assertEmptyHeaderName(key);
+    var val;
+    if (typeof key === 'symbol' || value === undefined || !key)
+      continue;
+    var isArray = Array.isArray(value);
     if (key[0] === ':') {
-      if (Array.isArray(value)) {
+      if (isArray) {
         if (value.length > 1)
-          throw new Error('HTTP/2 pseudo-headers must have a single value');
+          throw new errors.Error('ERR_HTTP2_PSEUDO_HEADERS_SINGLE_VALUE');
         value = value[0];
       }
       val = String(value);
       assertIllegalConnectionSpecificHeader(key, val, mapToHeaders);
       ret.unshift([key, val]);
-      ret.pop();
-      c++;
     } else {
-      if (Array.isArray(value) && value.length > 0) {
+      if (isArray) {
         for (var k = 0; k < value.length; k++) {
           val = String(value[k]);
           assertIllegalConnectionSpecificHeader(key, val, mapToHeaders);
-          ret[c++] = [key, val];
+          ret.push([key, val]);
         }
       } else {
         val = String(value);
         assertIllegalConnectionSpecificHeader(key, val, mapToHeaders);
-        ret[c++] = [key, val];
+        ret.push([key, val]);
       }
     }
   }
+
   return ret;
 }
 

--- a/test/parallel/test-http2-cookies.js
+++ b/test/parallel/test-http2-cookies.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer();
+
+const setCookie = [
+  'a=b',
+  'c=d; Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly'
+];
+
+// we use the lower-level API here
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+
+  assert(Array.isArray(headers.abc));
+  assert.strictEqual(headers.abc.length, 3);
+  assert.strictEqual(headers.abc[0], '1');
+  assert.strictEqual(headers.abc[1], '2');
+  assert.strictEqual(headers.abc[2], '3');
+  assert.strictEqual(typeof headers.cookie, 'string');
+  assert.strictEqual(headers.cookie, 'a=b; c=d; e=f');
+
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200,
+    'set-cookie': setCookie
+  });
+
+  stream.end('hello world');
+}
+
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+
+  const client = h2.connect(`http://localhost:${server.address().port}`);
+
+  const req = client.request({
+    ':path': '/',
+    abc: [1, 2, 3],
+    cookie: ['a=b', 'c=d', 'e=f'],
+  });
+  req.resume();
+
+  req.on('response', common.mustCall((headers) => {
+    assert(Array.isArray(headers['set-cookie']));
+    assert.deepStrictEqual(headers['set-cookie'], setCookie,
+                           'set-cookie header does not match');
+  }));
+
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+
+}));

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -1,0 +1,109 @@
+// Flags: --expose-internals
+'use strict';
+
+// Tests the internal utility function that is used to prepare headers
+// to pass to the internal binding layer.
+
+const common = require('../common');
+const assert = require('assert');
+const { mapToHeaders } = require('internal/http2/util');
+
+{
+  const headers = {
+    'abc': 1,
+    ':status': 200,
+    ':path': 'abc',
+    'xyz': [1, '2', { toString() { return '3'; } }, 4]
+  };
+
+  assert.deepStrictEqual(mapToHeaders(headers), [
+    [ ':path', 'abc' ],
+    [ ':status', '200' ],
+    [ 'abc', '1' ],
+    [ 'xyz', '1' ],
+    [ 'xyz', '2' ],
+    [ 'xyz', '3' ],
+    [ 'xyz', '4' ]
+  ]);
+}
+
+{
+  const headers = {
+    'abc': 1,
+    ':path': 'abc',
+    ':status': 200,
+    'xyz': [1, 2, 3, 4]
+  };
+
+  assert.deepStrictEqual(mapToHeaders(headers), [
+    [ ':status', '200' ],
+    [ ':path', 'abc' ],
+    [ 'abc', '1' ],
+    [ 'xyz', '1' ],
+    [ 'xyz', '2' ],
+    [ 'xyz', '3' ],
+    [ 'xyz', '4' ]
+  ]);
+}
+
+{
+  const headers = {
+    'abc': 1,
+    ':path': 'abc',
+    'xyz': [1, 2, 3, 4],
+    '': 1,
+    ':status': 200,
+    [Symbol('test')]: 1 // Symbol keys are ignored
+  };
+
+  assert.deepStrictEqual(mapToHeaders(headers), [
+    [ ':status', '200' ],
+    [ ':path', 'abc' ],
+    [ 'abc', '1' ],
+    [ 'xyz', '1' ],
+    [ 'xyz', '2' ],
+    [ 'xyz', '3' ],
+    [ 'xyz', '4' ]
+  ]);
+}
+
+{
+  // Only own properties are used
+  const base = { 'abc': 1 };
+  const headers = Object.create(base);
+  headers[':path'] = 'abc';
+  headers.xyz = [1, 2, 3, 4];
+  headers.foo = [];
+  headers[':status'] = 200;
+
+  assert.deepStrictEqual(mapToHeaders(headers), [
+    [ ':status', '200' ],
+    [ ':path', 'abc' ],
+    [ 'xyz', '1' ],
+    [ 'xyz', '2' ],
+    [ 'xyz', '3' ],
+    [ 'xyz', '4' ]
+  ]);
+}
+
+assert.throws(() => mapToHeaders({':status': [1, 2, 3]}),
+              common.expectsError({
+                code: 'ERR_HTTP2_PSEUDO_HEADERS_SINGLE_VALUE',
+                message: /^HTTP\/2 pseudo-headers must have a single value$/
+              }));
+
+assert.throws(() => mapToHeaders({':path': [1, 2, 3]}),
+              common.expectsError({
+                code: 'ERR_HTTP2_PSEUDO_HEADERS_SINGLE_VALUE',
+                message: /^HTTP\/2 pseudo-headers must have a single value$/
+              }));
+
+['connection', 'upgrade', 'http2-settings', 'te'].forEach((i) => {
+  assert.throws(() => mapToHeaders({[i]: 'abc'}),
+                common.expectsError({
+                  code: 'ERR_HTTP2_INVALID_CONNECTION_HEADERS',
+                  message: /^HTTP\/1 Connection specific headers are forbidden$/
+                }));
+});
+
+assert.doesNotThrow(() => mapToHeaders({ te: 'trailers' }));


### PR DESCRIPTION
* mapToHeaders function was not working correctly
* ensure that cookie headers are reassembled properly
* add test

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
http2