### PR TITLE
http2: statusCode should be a Number

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -101,6 +101,10 @@ function onSessionHeaders(id, cat, flags, headers) {
     headers[HTTP2_HEADER_COOKIE] =
       headers[HTTP2_HEADER_COOKIE].join('; ');
 
+  if (headers[HTTP2_HEADER_STATUS]) {
+    headers[HTTP2_HEADER_STATUS] |= 0;
+  }
+
   if (stream === undefined) {
     switch (owner.type) {
       case NGHTTP2_SESSION_SERVER:

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -74,7 +74,7 @@ server.listen(0, common.mustCall(function() {
     requestStream.session.on('stream', common.mustCall(onStream));
 
     requestStream.on('response', common.mustCall(function(headers, flags) {
-      assert.strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], 200);
       assert.ok(headers['date']);
       assert.strictEqual(flags, h2.constants.NGHTTP2_FLAG_END_HEADERS);
     }));

--- a/test/parallel/test-http2-compat-serverresponse-flushheaders.js
+++ b/test/parallel/test-http2-compat-serverresponse-flushheaders.js
@@ -31,7 +31,7 @@ server.listen(0, common.mustCall(function() {
     const request = client.request(headers);
     request.on('response', common.mustCall(function(headers, flags) {
       assert.strictEqual(headers['foo-bar'], undefined);
-      assert.strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], 200);
     }, 1));
     request.on('end', common.mustCall(function() {
       client.destroy();

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -39,7 +39,7 @@ server.listen(0, common.mustCall(function() {
     };
     const request = client.request(headers);
     request.on('response', common.mustCall(function(headers) {
-      assert.strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], 200);
       assert.strictEqual(headers['foo-bar'], 'abc123');
     }, 1));
     request.on('end', common.mustCall(function() {

--- a/test/parallel/test-http2-compat-serverresponse-writehead.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead.js
@@ -34,7 +34,7 @@ server.listen(0, common.mustCall(function() {
     const request = client.request(headers);
     request.on('response', common.mustCall(function(headers) {
       assert.strictEqual(headers['foo-bar'], 'abc123');
-      assert.strictEqual(headers[':status'], '404');
+      assert.strictEqual(headers[':status'], 404);
     }, 1));
     request.on('end', common.mustCall(function() {
       client.destroy();

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -38,7 +38,7 @@ function verifySecureSession(key, cert, ca, opts) {
       const req = client.request(headers);
 
       req.on('response', common.mustCall(function(headers) {
-        assert.strictEqual(headers[':status'], '200', 'status code is set');
+        assert.strictEqual(headers[':status'], 200, 'status code is set');
         assert.strictEqual(headers['content-type'], 'text/html',
                            'content type is set');
         assert(headers['date'], 'there is a date');

--- a/test/parallel/test-http2-create-client-session.js
+++ b/test/parallel/test-http2-create-client-session.js
@@ -38,7 +38,7 @@ server.on('listening', common.mustCall(function() {
     const req = client.request(headers);
 
     req.on('response', common.mustCall(function(headers) {
-      assert.strictEqual(headers[':status'], '200', 'status code is set');
+      assert.strictEqual(headers[':status'], 200, 'status code is set');
       assert.strictEqual(headers['content-type'], 'text/html',
                          'content type is set');
       assert(headers['date'], 'there is a date');

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -63,13 +63,13 @@ server.on('listening', common.mustCall(() => {
   // Additional informational headers
   req.on('headers', common.mustCall((headers) => {
     assert.notStrictEqual(headers, undefined);
-    assert.strictEqual(headers[':status'], '100');
+    assert.strictEqual(headers[':status'], 100);
   }, 2));
 
   // Response headers
   req.on('response', common.mustCall((headers) => {
     assert.notStrictEqual(headers, undefined);
-    assert.strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers[':status'], 200);
     assert.strictEqual(headers['content-type'], 'text/html');
   }));
 

--- a/test/parallel/test-http2-server-push-stream.js
+++ b/test/parallel/test-http2-server-push-stream.js
@@ -39,7 +39,7 @@ server.listen(0, common.mustCall(() => {
     assert.strictEqual(headers[':path'], '/foobar');
     assert.strictEqual(headers[':authority'], `localhost:${port}`);
     stream.on('push', common.mustCall((headers, flags) => {
-      assert.strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], 200);
       assert.strictEqual(headers['content-type'], 'text/html');
       assert.strictEqual(headers['x-push-data'], 'pushed by server');
     }));

--- a/test/parallel/test-http2-write-empty-string.js
+++ b/test/parallel/test-http2-write-empty-string.js
@@ -22,11 +22,11 @@ server.listen(0, common.mustCall(function() {
 
   let res = '';
 
-  req.on('response', (headers) => {
+  req.on('response', common.mustCall(function(headers) {
     assert.strictEqual(200, headers[':status']);
-  });
+  }));
 
-  req.on('data', function(chunk) {
+  req.on('data', (chunk) => {
     res += chunk;
   });
 

--- a/test/parallel/test-http2-write-empty-string.js
+++ b/test/parallel/test-http2-write-empty-string.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer(function(request, response) {
+  response.writeHead(200, {'Content-Type': 'text/plain'});
+  response.write('1\n');
+  response.write('');
+  response.write('2\n');
+  response.write('');
+  response.end('3\n');
+
+  this.close();
+});
+
+server.listen(0, common.mustCall(function() {
+  const client = http2.connect(`http://localhost:${this.address().port}`);
+  const headers = { ':path': '/' };
+  const req = client.request(headers).setEncoding('ascii');
+
+  let res = '';
+
+  req.on('response', (headers) => {
+    assert.strictEqual(200, headers[':status']);
+  });
+
+  req.on('data', function(chunk) {
+    res += chunk;
+  });
+
+  req.on('end', common.mustCall(function() {
+    assert.strictEqual('1\n2\n3\n', res);
+    client.destroy();
+  }));
+
+  req.end();
+}));


### PR DESCRIPTION
Fixes https://github.com/nodejs/http2/issues/118

Issue I have right now: somehow the server / client hangs and does not end the test. req.resume() or req.end() are not called in the http1 implementation in https://github.com/nodejs/http2/blob/master/test/parallel/test-http-write-empty-string.js, so I'm puzzled.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines]
(https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
http2, test