### PR TITLE
http2: improve padding callback

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -45,6 +45,8 @@ const kProceed = Symbol('proceed');
 const kDefaultSocketTimeout = 2 * 60 * 1000;
 const kRenegTest = /TLS session renegotiation disabled for this socket/;
 
+const paddingBuffer = new Uint32Array(binding.paddingArrayBuffer);
+
 const {
   NGHTTP2_CANCEL,
   NGHTTP2_DEFAULT_WEIGHT,
@@ -325,21 +327,23 @@ function onSessionShutdownComplete(status, wrap) {
   wrap[kOwner] = undefined;
 }
 
-// Returns the padding to use per frame. The selectPadding event is
-// emitted with three arguments: the length of frame data, the max
-// allowed length of the frame payload, and a return value object.
-// The return object has a single length property that is defaulted
-// to frameLen. The handler can change the value of length to specify
-// the padding to use. Note that this padding strategy is expensive
-// because the onSelectPadding is called once for each frame, which
-// means for each frame there's a call across the C++/JS boundary and
-// a trip through EventEmitter land. This likely is not going to be
-// the most efficient padding strategy to use.
-function onSelectPadding(frameLen, maxFramePayloadLen) {
-  const owner = this[kOwner];
-  const ret = {length: frameLen};
-  owner.emit('selectPadding', frameLen, maxFramePayloadLen, ret);
-  return Math.min(maxFramePayloadLen, Math.max(frameLen, ret.length | 0));
+// Returns the padding to use per frame. The selectPadding callback is set
+// on the options. It is invoked with two arguments, the frameLen, and the
+// maxPayloadLen. The method must return a numeric value within the range
+// frameLen <= n <= maxPayloadLen.
+function onSelectPadding(fn) {
+  assert(typeof fn === 'function',
+         'options.selectPadding must be a function. Please report this as a ' +
+         'bug in Node.js');
+  return function getPadding() {
+    const frameLen = paddingBuffer[0];
+    const maxFramePayloadLen = paddingBuffer[1];
+    paddingBuffer[2] = Math.min(maxFramePayloadLen,
+                                Math.max(frameLen,
+                                          fn(frameLen,
+                                            maxFramePayloadLen) | 0));
+
+  };
 }
 
 // Called when the socket is connected to handle a pending request.
@@ -456,7 +460,8 @@ function setupHandle(session, socket, type, options, settings) {
     handle.onstreamclose = onSessionStreamClose;
     handle.onerror = onSessionError;
     handle.onread = onSessionRead;
-    handle.ongetpadding = onSelectPadding;
+    if (typeof options.selectPadding === 'function')
+      handle.ongetpadding = onSelectPadding(options.selectPadding);
     handle.consume(socket._handle._externalStream);
     session.settings(settings);
     const state = session[kState];
@@ -1299,13 +1304,6 @@ function sessionOnStream(stream, headers, flags) {
   server.emit('stream', stream, headers, flags);
 }
 
-function sessionOnSelectPadding(frameLen, maxPayloadLen, ret) {
-  const server = this[kServer];
-  if (!server.emit('selectPadding', frameLen, maxPayloadLen, ret)) {
-    ret.length = frameLen;
-  }
-}
-
 function sessionOnPriority(stream, parent, weight, exclusive) {
   const server = this[kServer];
   server.emit('priority', stream, parent, weight, exclusive);
@@ -1336,7 +1334,6 @@ function connectionListener(socket) {
   const session = createServerSession(this[kOptions], socket, options.settings);
   session.on('error', sessionOnError);
   session.on('stream', sessionOnStream);
-  session.on('selectPadding', sessionOnSelectPadding);
   session.on('priority', sessionOnPriority);
 
   session[kServer] = this;
@@ -1471,9 +1468,6 @@ function createClientSession(options, socket) {
   socket.on('drain', socketOnDrain);
 
   session.on('error', clientSessionOnError);
-  // TODO(jasnell): provide client specific implementations
-  // session.on('stream', sessionOnStream);
-  // session.on('selectPadding', sessionOnSelectPadding);
 
   socket[kSession] = session;
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -237,6 +237,7 @@ inline Environment::~Environment() {
   delete[] http2_settings_buffer_;
   delete[] http2_session_state_buffer_;
   delete[] http2_stream_state_buffer_;
+  delete[] http2_padding_buffer_;
 }
 
 inline v8::Isolate* Environment::isolate() const {
@@ -392,6 +393,16 @@ inline double* Environment::http2_stream_state_buffer() const {
 inline void Environment::set_http2_stream_state_buffer(double* pointer) {
   CHECK_EQ(http2_stream_state_buffer_, nullptr);
   http2_stream_state_buffer_ = pointer;
+}
+
+inline uint32_t* Environment::http2_padding_buffer() const {
+  CHECK_NE(http2_padding_buffer_, nullptr);
+  return http2_padding_buffer_;
+}
+
+inline void Environment::set_http2_padding_buffer(uint32_t* pointer) {
+  CHECK_EQ(http2_padding_buffer_, nullptr);
+  http2_padding_buffer_ = pointer;
 }
 
 inline char* Environment::http_parser_buffer() const {

--- a/src/env.h
+++ b/src/env.h
@@ -517,6 +517,9 @@ class Environment {
   inline double* http2_stream_state_buffer() const;
   inline void set_http2_stream_state_buffer(double* pointer);
 
+  inline uint32_t* http2_padding_buffer() const;
+  inline void set_http2_padding_buffer(uint32_t* pointer);
+
   inline char* http_parser_buffer() const;
   inline void set_http_parser_buffer(char* buffer);
   inline char* http2_socket_buffer() const;
@@ -634,6 +637,7 @@ class Environment {
   int32_t* http2_settings_buffer_ = nullptr;
   double* http2_session_state_buffer_ = nullptr;
   double* http2_stream_state_buffer_ = nullptr;
+  uint32_t* http2_padding_buffer_ = nullptr;
 
   char* http_parser_buffer_;
   char* http2_socket_buffer_;

--- a/test/parallel/test-http2-padding-callback.js
+++ b/test/parallel/test-http2-padding-callback.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const h2 = require('http2');
+const { PADDING_STRATEGY_CALLBACK } = h2.constants;
+
+function selectPadding(frameLen, max) {
+  assert.strictEqual(typeof frameLen, 'number');
+  assert.strictEqual(typeof max, 'number');
+  assert(max >= frameLen);
+  return max;
+}
+
+const options = {
+  paddingStrategy: PADDING_STRATEGY_CALLBACK,
+  selectPadding: common.mustCall(selectPadding, 4)
+};
+
+const server = h2.createServer(options);
+server.on('stream', common.mustCall(onStream));
+
+function onStream(stream, headers, flags) {
+  stream.respond({
+    'content-type': 'text/html',
+    ':status': 200
+  });
+  stream.end('hello world');
+}
+
+server.listen(0);
+
+server.on('listening', common.mustCall(() => {
+  const client = h2.connect(`http://localhost:${server.address().port}`,
+                            options);
+
+  const req = client.request({ ':path': '/' });
+  req.on('response', common.mustCall());
+  req.resume();
+  req.on('end', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+  req.end();
+}));


### PR DESCRIPTION
* Make padding callback more efficient using an array buffer,
* Use an options callback instead of an event

There's not much else here we really should do. Padding is not super important and we shouldn't get too fancy with it. This makes the callback fairly efficient for what it is.

Fixes: https://github.com/nodejs/http2/issues/70

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
http2