### PR TITLE
http2: ALPN fallback to HTTP/1.1

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -611,6 +611,7 @@ server.listen(80);
   * `noRecvClientMagic` {boolean} (TODO: Add detail)
   * `paddingStrategy` {number} (TODO: Add detail)
   * `peerMaxConcurrentStreams` {number} (TODO: Add detail)
+  * `allowHTTP1` {boolean} Incoming client connections that do not support HTTP/2 will be downgraded to HTTP/1.x when set to `true`. The default value is `false`, which rejects non-HTTP/2 client connections.
   * `settings` {[Settings Object][]} The initial settings to send to the
     remote peer upon connection.
   * ...: Any [`tls.createServer()`][] options can be provided. For

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -611,7 +611,9 @@ server.listen(80);
   * `noRecvClientMagic` {boolean} (TODO: Add detail)
   * `paddingStrategy` {number} (TODO: Add detail)
   * `peerMaxConcurrentStreams` {number} (TODO: Add detail)
-  * `allowHTTP1` {boolean} Incoming client connections that do not support HTTP/2 will be downgraded to HTTP/1.x when set to `true`. The default value is `false`, which rejects non-HTTP/2 client connections.
+  * `allowHTTP1` {boolean} Incoming client connections that do not support 
+    HTTP/2 will be downgraded to HTTP/1.x when set to `true`. The default value
+    is `false`, which rejects non-HTTP/2 client connections.
   * `settings` {[Settings Object][]} The initial settings to send to the
     remote peer upon connection.
   * ...: Any [`tls.createServer()`][] options can be provided. For

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -181,6 +181,10 @@ class Http2ServerRequest extends Readable {
     return '2.0';
   }
 
+  get socket() {
+    return this.stream.session.socket;
+  }
+
   _read(nread) {
     var stream = this[kStream];
     if (stream) {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -181,10 +181,6 @@ class Http2ServerRequest extends Readable {
     return '2.0';
   }
 
-  get socket() {
-    return this.stream.session.socket;
-  }
-
   _read(nread) {
     var stream = this[kStream];
     if (stream) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1257,7 +1257,8 @@ function connectionListener(socket) {
   }
 
   // TLS ALPN fallback to HTTP/1.1
-  if (socket.alpnProtocol === false || socket.alpnProtocol === 'http/1.1') {
+  if ((options.allowHTTP1 === undefined || !!options.allowHTTP1 === true) &&
+    (socket.alpnProtocol === false || socket.alpnProtocol === 'http/1.1')) {
     return httpConnectionListener.call(this, socket);
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1257,8 +1257,9 @@ function connectionListener(socket) {
   }
 
   // TLS ALPN fallback to HTTP/1.1
-  if ((options.allowHTTP1 === undefined || !!options.allowHTTP1 === true) &&
-    (socket.alpnProtocol === false || socket.alpnProtocol === 'http/1.1')) {
+  if (options.allowHTTP1 === true &&
+    (socket.alpnProtocol === false ||
+    socket.alpnProtocol === 'http/1.1')) {
     return httpConnectionListener.call(this, socket);
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -13,6 +13,7 @@ const { Duplex } = require('stream');
 const { URL } = require('url');
 const { onServerStream } = require('internal/http2/compat');
 const { utcDate } = require('internal/http');
+const { _connectionListener: httpConnectionListener } = require('http');
 
 const {
   assertIsObject,
@@ -1255,6 +1256,11 @@ function connectionListener(socket) {
     socket.on('timeout', socketOnTimeout);
   }
 
+  // TLS ALPN fallback to HTTP/1.1
+  if (socket.alpnProtocol === false || socket.alpnProtocol === 'http/1.1') {
+    return httpConnectionListener.call(this, socket);
+  }
+
   socket.on('error', socketOnError);
   socket.on('resume', socketOnResume);
   socket.on('pause', socketOnPause);
@@ -1287,8 +1293,7 @@ function initializeOptions(options) {
 
 function initializeTLSOptions(options, servername) {
   options = initializeOptions(options);
-  options.ALPNProtocols = ['hc', 'h2'];
-  options.NPNProtocols = ['hc', 'h2'];
+  options.ALPNProtocols = ['h2', 'http/1.1'];
   if (servername !== undefined && options.servername === undefined) {
     options.servername = servername;
   }

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -50,8 +50,7 @@ function verifySecureSession(key, cert, ca, opts) {
       req.on('end', common.mustCall(() => {
         const jsonData = JSON.parse(data);
         assert.strictEqual(jsonData.servername, opts.servername || 'localhost');
-        assert(
-            jsonData.alpnProtocol === 'h2' || jsonData.alpnProtocol === 'hc');
+        assert.strictEqual(jsonData.alpnProtocol, 'h2');
         server.close();
         client.socket.destroy();
       }));
@@ -65,7 +64,6 @@ verifySecureSession(
     loadKey('agent8-key.pem'),
     loadKey('agent8-cert.pem'),
     loadKey('fake-startcom-root-cert.pem'));
-
 
 // Custom servername is specified.
 verifySecureSession(

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -22,9 +22,11 @@ const ca = loadKey('fake-startcom-root-cert.pem');
 const clientOptions = { secureContext: createSecureContext({ ca }) };
 
 function onRequest(request, response) {
+  const { socket: { alpnProtocol } } = request.httpVersion === '2.0' ?
+    request.stream.session : request;
   response.writeHead(200, { 'content-type': 'application/json' });
   response.end(JSON.stringify({
-    alpnProtocol: request.socket.alpnProtocol,
+    alpnProtocol,
     httpVersion: request.httpVersion
   }));
 }
@@ -59,7 +61,7 @@ function onSession(session) {
 // HTTP/2 & HTTP/1.1 server
 {
   const server = createSecureServer(
-    { cert, key },
+    { cert, key, allowHTTP1: true },
     mustCall(onRequest, 2)
   );
 
@@ -104,7 +106,7 @@ function onSession(session) {
 // HTTP/2-only server
 {
   const server = createSecureServer(
-    { cert, key, allowHTTP1: false },
+    { cert, key },
     mustCall(onRequest)
   );
 

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { fixturesDir, mustCall } = require('../common');
+const { strictEqual } = require('assert');
+const { join } = require('path');
+const { readFileSync } = require('fs');
+const { createSecureContext } = require('tls');
+const { createSecureServer } = require('http2');
+const { get } = require('https');
+const { parse } = require('url');
+
+const key = loadKey('agent8-key.pem');
+const cert = loadKey('agent8-cert.pem');
+const ca = loadKey('fake-startcom-root-cert.pem');
+
+function loadKey(keyname) {
+  return readFileSync(
+    join(fixturesDir, 'keys', keyname), 'binary');
+}
+
+const server = createSecureServer(
+  { cert, key },
+  mustCall((request, response) => {
+    response.writeHead(200, 'OK', { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ alpnProtocol: request.socket.alpnProtocol }));
+  })
+);
+
+server.listen(0);
+
+server.on('listening', mustCall(() => {
+  const clientOptions = Object.assign(
+    { secureContext: createSecureContext({ ca }) },
+    parse(`https://localhost:${server.address().port}`)
+  );
+
+  get(clientOptions, (response) => {
+    strictEqual(response.statusCode, 200);
+    strictEqual(response.statusMessage, 'OK');
+    strictEqual(response.headers['content-type'], 'application/json');
+
+    response.setEncoding('utf8');
+    let raw = '';
+    response.on('data', (chunk) => { raw += chunk; });
+    response.on('end', mustCall(() => {
+      const data = JSON.parse(raw);
+      strictEqual(data.alpnProtocol, false);
+
+      server.close();
+    }));
+  });
+}));

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -109,14 +109,10 @@ function loadKey(keyname) {
     let count = 2;
 
     // HTTP/2 client
-    connect(
-      origin,
-      { secureContext: createSecureContext({ ca }) },
-      mustCall((session) => {
-        session.destroy();
-        if (--count === 0) server.close();
-      })
-    );
+    connect(origin, clientOptions, mustCall((session) => {
+      session.destroy();
+      if (--count === 0) server.close();
+    }));
 
     // HTTP/1.1 client
     get(Object.assign(parse(origin), clientOptions), mustNotCall())

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -9,26 +9,58 @@ const { createSecureServer, connect } = require('http2');
 const { get } = require('https');
 const { parse } = require('url');
 
+const countdown = (count, done) => () => --count === 0 && done();
+
+function loadKey(keyname) {
+  return readFileSync(join(fixturesDir, 'keys', keyname));
+}
+
 const key = loadKey('agent8-key.pem');
 const cert = loadKey('agent8-cert.pem');
 const ca = loadKey('fake-startcom-root-cert.pem');
 
-function loadKey(keyname) {
-  return readFileSync(
-    join(fixturesDir, 'keys', keyname), 'binary');
+const clientOptions = { secureContext: createSecureContext({ ca }) };
+
+function onRequest(request, response) {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({
+    alpnProtocol: request.socket.alpnProtocol,
+    httpVersion: request.httpVersion
+  }));
+}
+
+function onSession(session) {
+  const headers = {
+    ':path': '/',
+    ':method': 'GET',
+    ':scheme': 'https',
+    ':authority': `localhost:${this.server.address().port}`
+  };
+
+  const request = session.request(headers);
+  request.on('response', mustCall((headers) => {
+    strictEqual(headers[':status'], '200');
+    strictEqual(headers['content-type'], 'application/json');
+  }));
+  request.setEncoding('utf8');
+  let raw = '';
+  request.on('data', (chunk) => { raw += chunk; });
+  request.on('end', mustCall(() => {
+    const { alpnProtocol, httpVersion } = JSON.parse(raw);
+    strictEqual(alpnProtocol, 'h2');
+    strictEqual(httpVersion, '2.0');
+
+    session.destroy();
+    this.cleanup();
+  }));
+  request.end();
 }
 
 // HTTP/2 & HTTP/1.1 server
 {
   const server = createSecureServer(
     { cert, key },
-    mustCall((request, response) => {
-      response.writeHead(200, { 'content-type': 'application/json' });
-      response.end(JSON.stringify({
-        alpnProtocol: request.socket.alpnProtocol,
-        httpVersion: request.httpVersion
-      }));
-    }, 2)
+    mustCall(onRequest, 2)
   );
 
   server.listen(0);
@@ -36,40 +68,14 @@ function loadKey(keyname) {
   server.on('listening', mustCall(() => {
     const port = server.address().port;
     const origin = `https://localhost:${port}`;
-    const clientOptions = { secureContext: createSecureContext({ ca }) };
 
-    let count = 2;
+    const cleanup = countdown(2, () => server.close());
 
     // HTTP/2 client
     connect(
       origin,
-      { secureContext: createSecureContext({ ca }) },
-      mustCall((session) => {
-        const headers = {
-          ':path': '/',
-          ':method': 'GET',
-          ':scheme': 'https',
-          ':authority': `localhost:${port}`
-        };
-
-        const request = session.request(headers);
-        request.on('response', mustCall((headers) => {
-          strictEqual(headers[':status'], '200');
-          strictEqual(headers['content-type'], 'application/json');
-        }));
-        request.setEncoding('utf8');
-        let raw = '';
-        request.on('data', (chunk) => { raw += chunk; });
-        request.on('end', mustCall(() => {
-          const data = JSON.parse(raw);
-          strictEqual(data.alpnProtocol, 'h2');
-          strictEqual(data.httpVersion, '2.0');
-
-          session.destroy();
-          if (--count === 0) server.close();
-        }));
-        request.end();
-      })
+      clientOptions,
+      mustCall(onSession.bind({ cleanup, server }))
     );
 
     // HTTP/1.1 client
@@ -84,11 +90,11 @@ function loadKey(keyname) {
         let raw = '';
         response.on('data', (chunk) => { raw += chunk; });
         response.on('end', mustCall(() => {
-          const data = JSON.parse(raw);
-          strictEqual(data.alpnProtocol, false);
-          strictEqual(data.httpVersion, '1.1');
+          const { alpnProtocol, httpVersion } = JSON.parse(raw);
+          strictEqual(alpnProtocol, false);
+          strictEqual(httpVersion, '1.1');
 
-          if (--count === 0) server.close();
+          cleanup();
         }));
       })
     );
@@ -97,27 +103,28 @@ function loadKey(keyname) {
 
 // HTTP/2-only server
 {
-  const server = createSecureServer({ cert, key, allowHTTP1: false });
+  const server = createSecureServer(
+    { cert, key, allowHTTP1: false },
+    mustCall(onRequest)
+  );
 
   server.listen(0);
 
   server.on('listening', mustCall(() => {
     const port = server.address().port;
     const origin = `https://localhost:${port}`;
-    const clientOptions = { secureContext: createSecureContext({ ca }) };
 
-    let count = 2;
+    const cleanup = countdown(2, () => server.close());
 
     // HTTP/2 client
-    connect(origin, clientOptions, mustCall((session) => {
-      session.destroy();
-      if (--count === 0) server.close();
-    }));
+    connect(
+      origin,
+      clientOptions,
+      mustCall(onSession.bind({ cleanup, server }))
+    );
 
     // HTTP/1.1 client
     get(Object.assign(parse(origin), clientOptions), mustNotCall())
-      .on('error', mustCall(() => {
-        if (--count === 0) server.close();
-      }));
+      .on('error', mustCall(cleanup));
   }));
 }

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -106,15 +106,22 @@ function loadKey(keyname) {
     const origin = `https://localhost:${port}`;
     const clientOptions = { secureContext: createSecureContext({ ca }) };
 
+    let count = 2;
+
     // HTTP/2 client
     connect(
       origin,
       { secureContext: createSecureContext({ ca }) },
-      mustCall((session) => { session.destroy(); })
+      mustCall((session) => {
+        session.destroy();
+        if (--count === 0) server.close();
+      })
     );
 
     // HTTP/1.1 client
     get(Object.assign(parse(origin), clientOptions), mustNotCall())
-      .on('error', mustCall(server.close.bind(server)));
+      .on('error', mustCall(() => {
+        if (--count === 0) server.close();
+      }));
   }));
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

Fixes #122 

Well then, this was a lot easier than I thought it would be. 😌

- Deprecate NPN since this is not part of the HTTP/2 standard (and poorly documented AFAICT).
- Announce ALPN as `h2` or `http/1.1`, as per [IANA-registered protocol IDs](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids).
- For backwards compatibility pass the non-HTTP/2 socket to the HTTP/1.1 parser. This then emits `request` events on the `Http2SecureServer` instance. Analogous to the `https` module.

Note 1: ~~Some other tests are failing. Not sure if related to this patch.~~ TIL `--expose-internals`

Note 2: Only doing fallback to https clients. Not for plaintext http since ALPN is inherently TLS-only. Should use the [magic number to sniff plaintext http](https://tools.ietf.org/html/rfc7540#section-3.5).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2