### PR TITLE
http2: allow specifying servername in options

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1289,7 +1289,7 @@ function initializeTLSOptions(options, servername) {
   options = initializeOptions(options);
   options.ALPNProtocols = ['hc', 'h2'];
   options.NPNProtocols = ['hc', 'h2'];
-  if (servername !== undefined) {
+  if (servername !== undefined && options.servername === undefined) {
     options.servername = servername;
   }
   return options;

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -7,19 +7,10 @@ const fs = require('fs');
 const tls = require('tls');
 const h2 = require('http2');
 
-const key = loadKey('agent8-key.pem');
-const cert = loadKey('agent8-cert.pem');
-const ca = loadKey('fake-startcom-root-cert.pem');
-
 function loadKey(keyname) {
   return fs.readFileSync(
     path.join(common.fixturesDir, 'keys', keyname), 'binary');
 }
-
-const server = h2.createSecureServer({cert, key});
-
-// we use the lower-level API here
-server.on('stream', common.mustCall(onStream));
 
 function onStream(stream) {
   stream.respond({
@@ -33,33 +24,52 @@ function onStream(stream) {
   }));
 }
 
-server.listen(0);
+function verifySecureSession(key, cert, ca, opts) {
+  const server = h2.createSecureServer({cert, key});
+  server.on('stream', common.mustCall(onStream));
+  server.listen(0);
+  server.on('listening', common.mustCall(function() {
+    const headers = { ':path': '/' };
+    if (!opts) {
+      opts = {};
+    }
+    opts.secureContext = tls.createSecureContext({ca});
+    const client = h2.connect(`https://localhost:${this.address().port}`, opts, function() {
+      const req = client.request(headers);
 
-server.on('listening', common.mustCall(function() {
+      req.on('response', common.mustCall(function(headers) {
+        assert.strictEqual(headers[':status'], '200', 'status code is set');
+        assert.strictEqual(headers['content-type'], 'text/html',
+                           'content type is set');
+        assert(headers['date'], 'there is a date');
+      }));
 
-  const headers = { ':path': '/' };
+      let data = '';
+      req.setEncoding('utf8');
+      req.on('data', (d) => data += d);
+      req.on('end', common.mustCall(() => {
+        const jsonData = JSON.parse(data);
+        assert.strictEqual(jsonData.servername, opts.servername || 'localhost');
+        assert(
+            jsonData.alpnProtocol === 'h2' || jsonData.alpnProtocol === 'hc');
+        server.close();
+        client.socket.destroy();
+      }));
+      req.end();
+    });
+  }));
+}
 
-  const clientOptions = {secureContext: tls.createSecureContext({ca})};
-  const client = h2.connect(`https://localhost:${this.address().port}`, clientOptions, function() {
-    const req = client.request(headers);
+// The server can be connected as 'localhost'.
+verifySecureSession(
+    loadKey('agent8-key.pem'),
+    loadKey('agent8-cert.pem'),
+    loadKey('fake-startcom-root-cert.pem'));
 
-    req.on('response', common.mustCall(function(headers) {
-      assert.strictEqual(headers[':status'], '200', 'status code is set');
-      assert.strictEqual(headers['content-type'], 'text/html',
-                         'content type is set');
-      assert(headers['date'], 'there is a date');
-    }));
 
-    let data = '';
-    req.setEncoding('utf8');
-    req.on('data', (d) => data += d);
-    req.on('end', common.mustCall(() => {
-      const jsonData = JSON.parse(data);
-      assert.strictEqual(jsonData.servername, 'localhost');
-      assert(jsonData.alpnProtocol === 'h2' || jsonData.alpnProtocol === 'hc');
-      server.close();
-      client.socket.destroy();
-    }));
-    req.end();
-  });
-}));
+// Custom servername is specified.
+verifySecureSession(
+    loadKey('agent1-key.pem'),
+    loadKey('agent1-cert.pem'),
+    loadKey('ca1-cert.pem'),
+    {servername: 'agent1'});


### PR DESCRIPTION
I've noticed that it always use the host name for the SNI parameter, but I think it's better to allow customizing through the options.

##### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
http2