### PR TITLE
http2: request.socket|connection

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -227,8 +227,6 @@ process has completed.
 A reference to the [`net.Socket`][] or [`tls.TLSSocket`][] to which this
 `Http2Session` instance is bound.
 
-Directly reading from and writing to the socket is strongly discouraged.
-
 #### http2session.state
 
 * Value: {Object}

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -227,6 +227,8 @@ process has completed.
 A reference to the [`net.Socket`][] or [`tls.TLSSocket`][] to which this
 `Http2Session` instance is bound.
 
+Directly reading from and writing to the socket is strongly discouraged.
+
 #### http2session.state
 
 * Value: {Object}

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -181,6 +181,14 @@ class Http2ServerRequest extends Readable {
     return '2.0';
   }
 
+  get socket() {
+    return this.stream.session.socket;
+  }
+
+  get connection() {
+    return this.socket;
+  }
+
   _read(nread) {
     var stream = this[kStream];
     if (stream) {

--- a/test/parallel/test-http2-compat-serverrequest.js
+++ b/test/parallel/test-http2-compat-serverrequest.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const h2 = require('http2');
+const net = require('net');
 
 // Http2ServerRequest should expose convenience properties
 
@@ -22,8 +23,8 @@ server.listen(0, common.mustCall(function() {
     assert.strictEqual(request.httpVersionMajor, expected.httpVersionMajor);
     assert.strictEqual(request.httpVersionMinor, expected.httpVersionMinor);
 
-    assert.ok(request.socket);
-    assert.ok(request.connection);
+    assert.ok(request.socket instanceof net.Socket);
+    assert.ok(request.connection instanceof net.Socket);
     assert.strictEqual(request.socket, request.connection);
 
     response.stream.on('finish', common.mustCall(function() {

--- a/test/parallel/test-http2-compat-serverrequest.js
+++ b/test/parallel/test-http2-compat-serverrequest.js
@@ -22,6 +22,10 @@ server.listen(0, common.mustCall(function() {
     assert.strictEqual(request.httpVersionMajor, expected.httpVersionMajor);
     assert.strictEqual(request.httpVersionMinor, expected.httpVersionMinor);
 
+    assert.ok(request.socket);
+    assert.ok(request.connection);
+    assert.strictEqual(request.socket, request.connection);
+
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

As discussed in: https://github.com/nodejs/http2/pull/125#discussion_r116943863

Adds `request.socket` and `request.connection` for compatibility with documented HTTP APIs:

- > message.socket
  > Added in: v0.3.0
  > <net.Socket>
  > The net.Socket object associated with the connection.
  > https://nodejs.org/api/http.html#http_message_socket
- > Event: 'connection'
  > [...]
  > The socket can also be accessed at request.connection.
  > https://nodejs.org/api/http.html#http_event_connection

Use case: I found that popular packages like [cookies](https://npmjs.org/package/cookies) (NPM: >500k/mo) [make use of this to detect the TLS context](https://github.com/pillarjs/cookies/blob/master/index.js#L87).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2