### PR TITLE
http2: Reject incompatible TLS ALPN handshakes

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -749,6 +749,13 @@ The `'socketError'` event is emitted when an `'error'` event is emitted by
 a `Socket` associated with the server. If no listener is registered for this
 event, an `'error'` event is emitted on the `Socket` instance instead.
 
+#### Event: 'unknownProtocol'
+
+The `'unknownProtocol'` event is emitted when a connecting client fails to
+negotiate an allowed protocol (i.e. HTTP/2 or HTTP/1.1). The event handler
+receives the socket for handling. If no listener is registered for this event,
+the connection is terminated. See the 
+
 #### Event: 'stream'
 
 The `'stream'` event is emitted when a `'stream'` event has been emitted by
@@ -864,9 +871,7 @@ server.listen(80);
 * `options` {Object}
   * `allowHTTP1` {boolean} Incoming client connections that do not support
     HTTP/2 will be downgraded to HTTP/1.x when set to `true`. The default value
-    is `false`, which rejects non-HTTP/2 client connections by either emitting
-    a `'socketError'` event, if a handler is registered, or else disconnecing
-    the remote peer and emitting an `'error'` event on the socket.
+    is `false`. See the [`'unknownProtocol'`][] event.
   * `maxDefaultDynamicTableSize` {number} (TODO: Add detail)
   * `maxReservedRemoteStreams` {number} (TODO: Add detail)
   * `maxSendHeaderBlockLength` {number} (TODO: Add detail)
@@ -1113,3 +1118,4 @@ TBD
 [Settings Object]: #http2_settings_object
 [Using options.selectPadding]: #http2_using_options_selectpadding
 [error code]: #error_codes
+[`'unknownProtocol'`]: #http2_event_unknownprotocol

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -437,7 +437,7 @@ an `Http2Stream`.
 
 #### Event: 'fetchTrailers'
 
-The `'fetchTrailers`' event is emitted by the `Http2Stream` immediately after
+The `'fetchTrailers'` event is emitted by the `Http2Stream` immediately after
 queuing the last chunk of payload data to be sent. The listener callback is
 passed a single object (with a `null` prototype) that the listener may used
 to specify the trailing header fields to send to the peer.
@@ -696,7 +696,7 @@ an `Http2Session` object. If no listener is registered for this event, an
 
 #### Event: 'socketError'
 
-The `'socketError`' event is emitted when an `'error'` event is emitted by
+The `'socketError'` event is emitted when an `'error'` event is emitted by
 a `Socket` associated with the server. If no listener is registered for this
 event, an `'error'` event is emitted.
 
@@ -745,7 +745,7 @@ an `Http2Session` object. If no listener is registered for this event, an
 
 #### Event: 'socketError'
 
-The `'socketError`' event is emitted when an `'error'` event is emitted by
+The `'socketError'` event is emitted when an `'error'` event is emitted by
 a `Socket` associated with the server. If no listener is registered for this
 event, an `'error'` event is emitted on the `Socket` instance instead.
 
@@ -864,7 +864,9 @@ server.listen(80);
 * `options` {Object}
   * `allowHTTP1` {boolean} Incoming client connections that do not support
     HTTP/2 will be downgraded to HTTP/1.x when set to `true`. The default value
-    is `false`, which rejects non-HTTP/2 client connections.
+    is `false`, which rejects non-HTTP/2 client connections by either emitting
+    a `'socketError'` event, if a handler is registered, or else disconnecing
+    the remote peer and emitting an `'error'` event on the socket.
   * `maxDefaultDynamicTableSize` {number} (TODO: Add detail)
   * `maxReservedRemoteStreams` {number} (TODO: Add detail)
   * `maxSendHeaderBlockLength` {number} (TODO: Add detail)

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -181,7 +181,6 @@ E('ERR_SOCKET_BAD_TYPE',
 E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
 E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536');
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
-E('ERR_SOCKET_REJECT_HTTP1', 'HTTP/1 not allowed');
 // Add new errors from here...
 
 function invalidArgType(name, expected, actual) {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -181,6 +181,7 @@ E('ERR_SOCKET_BAD_TYPE',
 E('ERR_SOCKET_CANNOT_SEND', 'Unable to send data');
 E('ERR_SOCKET_BAD_PORT', 'Port should be > 0 and < 65536');
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running');
+E('ERR_SOCKET_REJECT_HTTP1', 'HTTP/1 not allowed');
 // Add new errors from here...
 
 function invalidArgType(name, expected, actual) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1619,11 +1619,14 @@ function connectionListener(socket) {
     socket.on('timeout', socketOnTimeout);
   }
 
-  // TLS ALPN fallback to HTTP/1.1
-  if (options.allowHTTP1 === true &&
-    (socket.alpnProtocol === false ||
-    socket.alpnProtocol === 'http/1.1')) {
-    return httpConnectionListener.call(this, socket);
+  if (socket.alpnProtocol === false || socket.alpnProtocol === 'http/1.1') {
+    if (options.allowHTTP1 === true) {
+      // Fallback to HTTP/1.1
+      return httpConnectionListener.call(this, socket);
+    } else {
+      // Reject non-HTTP/2 client
+      return socket.destroy();
+    }
   }
 
   socket.on('error', socketOnError);
@@ -1658,10 +1661,11 @@ function initializeOptions(options) {
 
 function initializeTLSOptions(options, servername) {
   options = initializeOptions(options);
-  options.ALPNProtocols = ['h2', 'http/1.1'];
-  if (servername !== undefined && options.servername === undefined) {
+  options.ALPNProtocols = ['h2'];
+  if (options.allowHTTP1 === true)
+    options.ALPNProtocols.push('http/1.1');
+  if (servername !== undefined && options.servername === undefined)
     options.servername = servername;
-  }
   return options;
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1623,12 +1623,12 @@ function connectionListener(socket) {
     if (options.allowHTTP1 === true) {
       // Fallback to HTTP/1.1
       return httpConnectionListener.call(this, socket);
+    } else if (this.emit('unknownProtocol', socket)) {
+      // Let event handler deal with the socket
+      return;
     } else {
       // Reject non-HTTP/2 client
-      return process.nextTick(
-        socketOnError.bind(socket),
-        new errors.TypeError('ERR_SOCKET_REJECT_HTTP1')
-      );
+      return socket.destroy();
     }
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1625,7 +1625,10 @@ function connectionListener(socket) {
       return httpConnectionListener.call(this, socket);
     } else {
       // Reject non-HTTP/2 client
-      return socket.destroy();
+      return process.nextTick(
+        socketOnError.bind(socket),
+        new errors.TypeError('ERR_SOCKET_REJECT_HTTP1')
+      );
     }
   }
 

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -4,8 +4,7 @@ const {
   fixturesDir,
   mustCall,
   mustNotCall,
-  platformTimeout,
-  expectsError
+  platformTimeout
 } = require('../common');
 const { strictEqual } = require('assert');
 const { join } = require('path');

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -4,7 +4,8 @@ const {
   fixturesDir,
   mustCall,
   mustNotCall,
-  platformTimeout
+  platformTimeout,
+  expectsError
 } = require('../common');
 const { strictEqual } = require('assert');
 const { join } = require('path');
@@ -126,6 +127,15 @@ function onSession(session) {
     { cert, key },
     mustCall(onRequest)
   );
+
+  const expectedRejection = mustCall(expectsError({
+    code: 'ERR_SOCKET_REJECT_HTTP1',
+    type: TypeError,
+    message: 'HTTP/1 not allowed'
+  }), 2);
+  server.on('secureConnection', mustCall((socket) => {
+    socket.on('error', expectedRejection);
+  }, 3));
 
   server.listen(0);
 

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -128,14 +128,9 @@ function onSession(session) {
     mustCall(onRequest)
   );
 
-  const expectedRejection = mustCall(expectsError({
-    code: 'ERR_SOCKET_REJECT_HTTP1',
-    type: TypeError,
-    message: 'HTTP/1 not allowed'
-  }), 2);
-  server.on('secureConnection', mustCall((socket) => {
-    socket.on('error', expectedRejection);
-  }, 3));
+  server.on('unknownProtocol', mustCall((socket) => {
+    socket.destroy();
+  }, 2));
 
   server.listen(0);
 

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const { fixturesDir, mustCall, mustNotCall } = require('../common');
+const {
+  fixturesDir,
+  mustCall,
+  mustNotCall,
+  platformTimeout
+} = require('../common');
 const { strictEqual } = require('assert');
 const { join } = require('path');
 const { readFileSync } = require('fs');
@@ -8,8 +13,20 @@ const { createSecureContext } = require('tls');
 const { createSecureServer, connect } = require('http2');
 const { get } = require('https');
 const { parse } = require('url');
+const { connect: tls } = require('tls');
 
 const countdown = (count, done) => () => --count === 0 && done();
+
+function expire(callback, ttl) {
+  const timeout = setTimeout(
+    mustNotCall('Callback expired'),
+    platformTimeout(ttl)
+  );
+  return function expire() {
+    clearTimeout(timeout);
+    return callback();
+  };
+}
 
 function loadKey(keyname) {
   return readFileSync(join(fixturesDir, 'keys', keyname));
@@ -68,7 +85,7 @@ function onSession(session) {
   server.listen(0);
 
   server.on('listening', mustCall(() => {
-    const port = server.address().port;
+    const { port } = server.address();
     const origin = `https://localhost:${port}`;
 
     const cleanup = countdown(2, () => server.close());
@@ -113,10 +130,10 @@ function onSession(session) {
   server.listen(0);
 
   server.on('listening', mustCall(() => {
-    const port = server.address().port;
+    const { port } = server.address();
     const origin = `https://localhost:${port}`;
 
-    const cleanup = countdown(2, () => server.close());
+    const cleanup = countdown(3, () => server.close());
 
     // HTTP/2 client
     connect(
@@ -128,5 +145,9 @@ function onSession(session) {
     // HTTP/1.1 client
     get(Object.assign(parse(origin), clientOptions), mustNotCall())
       .on('error', mustCall(cleanup));
+
+    // Incompatible ALPN TLS client
+    tls(Object.assign({ port, ALPNProtocols: ['fake'] }, clientOptions))
+      .on('error', expire(mustCall(cleanup), 200));
   }));
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

1. Only announce `http/1.1` in ALPN when the fallback is allowed.
1. Immediately destroy connections that do not support HTTP/2 when the HTTP/1 fallback is not allowed. Previously these connections would instantiate an Http2Session and linger until they timed out or caused a protocol error.

Note: The Node.js API does not seem to allow rejecting TLS handshakes at the ALPN-level (as described in [RFC 7301 3.2](https://tools.ietf.org/html/rfc7301#section-3.2)). Therefore we do not differentiate between TLS clients that failed to match an ALPN protocol, and clients that simply do not support ALPN. In practice this should make little, if any, difference. Should consider adding strict ALPN negotiation as an option to Node.js core TLS though.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2
