### PR TITLE
http2: fix http2-server-startup

### DIFF
--- a/test/parallel/test-http2-server-startup.js
+++ b/test/parallel/test-http2-server-startup.js
@@ -74,8 +74,11 @@ assert.doesNotThrow(() => {
   server.setTimeout(common.platformTimeout(1000));
   server.listen(0, common.mustCall(() => {
     const port = server.address().port;
-    client = tls.connect({port: port, rejectUnauthorized: false},
-                         common.mustCall());
+    client = tls.connect({
+      port: port,
+      rejectUnauthorized: false,
+      ALPNProtocols: ['h2']
+    }, common.mustCall());
   }));
   timer = setTimeout(() => assert.fail('server timeout failed'),
                      common.platformTimeout(1100));


### PR DESCRIPTION
9b6b0676221903592ba5a8145dfd10b87cc60ce6 broke the test... this fixes it

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
