### PR TITLE
http2: serverrequest setter

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -220,11 +220,22 @@ class Http2ServerRequest extends Readable {
     return this.path;
   }
 
+  set url(url) {
+    this.path = url;
+  }
+
   get path() {
     var headers = this[kHeaders];
     if (headers === undefined)
       return;
     return headers[constants.HTTP2_HEADER_PATH];
+  }
+
+  set path(path) {
+    var headers = this[kHeaders];
+    if (headers === undefined)
+      headers = this[kHeaders] = Object.create(null);
+    headers[constants.HTTP2_HEADER_PATH] = path;
   }
 
   setTimeout(msecs, callback) {

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -36,6 +36,14 @@ server.listen(0, common.mustCall(function() {
       assert.strictEqual(rawHeaders[position + 1], value);
     }
 
+    request.url = '/one';
+    assert.strictEqual(request.url, '/one');
+    assert.strictEqual(request.path, '/one');
+
+    request.path = '/two';
+    assert.strictEqual(request.url, '/two');
+    assert.strictEqual(request.path, '/two');
+
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));


### PR DESCRIPTION
Adding a setter for `ServerRequest.url` (and its `.path` alias).

This fixes compatibility with the popular Connect framework.

The `req.url` property is "patched" by Connect in a few places. This throws when there is no setter.

[Example:](https://github.com/senchalabs/connect/blob/05fae3d9c9a6fa44d1bb274789645a92fbaac17b/index.js#L137
)
```js
req.url = req.url.substr(1);
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)

http2