### PR TITLE
http2: Bandaid for infinite loop & memory leak

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -821,7 +821,9 @@ void Http2Session::Send(uv_buf_t* buf, size_t length) {
   HandleScope scope(env()->isolate());
   SessionSendBuffer* req = ContainerOf(&SessionSendBuffer::buffer_, buf);
   uv_buf_t actual = uv_buf_init(buf->base, length);
-  if (stream_->DoWrite(req, &actual, 1, nullptr)) {
+  if (length == 0) {
+    req->OnDone(req, 0);
+  } else if (stream_->DoWrite(req, &actual, 1, nullptr)) {
     req->Dispose();
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

This guard clause eliminates most (like, 99%) of the memory leaking and CPU usage reported in #153. Still seems like there are other leaks elsewhere, but this at least makes the server usable again.

Disclaimer: I don't know what I'm doing in C++ here. 🐒

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2