### PR TITLE
http2: more updates, add command line flag to enable

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -170,6 +170,13 @@ added: v6.0.0
 
 Silence all process warnings (including deprecations).
 
+### `--expose-http2`
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable the experimental `'http2'` module.
+
 ### `--napi-modules`
 <!-- YAML
 added: v8.0.0

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -9,6 +9,9 @@ can be accessed using:
 const http2 = require('http2');
 ```
 
+*Note*: Node.js must be launched with the `--expose-http2` command line flag
+in order to use the `'http2'` module.
+
 ## Core API
 
 The Core API provides a low-level interface designed specifically around

--- a/doc/node.1
+++ b/doc/node.1
@@ -131,6 +131,10 @@ Emit pending deprecation warnings.
 Silence all process warnings (including deprecations).
 
 .TP
+.BR \-\-expose\-http2
+Enable the experimental `'http2'` module.
+
+.TP
 .BR \-\-napi\-modules
 Enable loading native modules compiled with the ABI-stable Node.js API (N-API)
 (experimental).

--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -478,6 +478,11 @@
   NativeModule._source = process.binding('natives');
   NativeModule._cache = {};
 
+  const config = process.binding('config');
+
+  if (!config.exposeHTTP2)
+    delete NativeModule._source.http2;
+
   NativeModule.require = function(id) {
     if (id === 'native_module') {
       return NativeModule;
@@ -515,8 +520,6 @@
   NativeModule.exists = function(id) {
     return NativeModule._source.hasOwnProperty(id);
   };
-
-  const config = process.binding('config');
 
   if (config.exposeInternals) {
     NativeModule.nonInternalExists = NativeModule.exists;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -45,11 +45,21 @@ const TLSServer = tls.Server;
 
 const kInspect = require('internal/util').customInspectSymbol;
 
+const kAuthority = Symbol('authority');
 const kDestroySocket = Symbol('destroy-socket');
+const kHandle = Symbol('handle');
+const kID = Symbol('id');
 const kInit = Symbol('init');
 const kLocalSettings = Symbol('local-settings');
-const kRemoteSettings = Symbol('remote-settings');
+const kOptions = Symbol('options');
 const kProceed = Symbol('proceed');
+const kProtocol = Symbol('protocol');
+const kRemoteSettings = Symbol('remote-settings');
+const kServer = Symbol('server');
+const kSession = Symbol('session');
+const kSocket = Symbol('socket');
+const kState = Symbol('state');
+const kType = Symbol('type');
 
 const kDefaultSocketTimeout = 2 * 60 * 1000;
 const kRenegTest = /TLS session renegotiation disabled for this socket/;
@@ -107,9 +117,9 @@ function sessionName(type) {
 function onSessionHeaders(id, cat, flags, headers) {
   _unrefActive(this);
   const owner = this._owner;
-  debug(`[${sessionName(owner.type)}] headers were received on ` +
+  debug(`[${sessionName(owner[kType])}] headers were received on ` +
         `stream ${id}: ${cat}`);
-  const streams = owner._state.streams;
+  const streams = owner[kState].streams;
 
   const endOfStream = !!(flags & NGHTTP2_FLAG_END_STREAM);
   let stream = streams.get(id);
@@ -118,7 +128,7 @@ function onSessionHeaders(id, cat, flags, headers) {
   const obj = toHeaderObject(headers);
 
   if (stream === undefined) {
-    switch (owner.type) {
+    switch (owner[kType]) {
       case NGHTTP2_SESSION_SERVER:
         stream = new ServerHttp2Stream(owner, id, { readable: !endOfStream });
         break;
@@ -163,7 +173,7 @@ function onSessionHeaders(id, cat, flags, headers) {
                     'Internal HTTP/2 Error. Invalid headers category. Please ' +
                     'report this as a bug in Node.js');
     }
-    debug(`[${sessionName(owner.type)}] emitting stream '${event}' event`);
+    debug(`[${sessionName(owner[kType])}] emitting stream '${event}' event`);
     stream.emit(event, obj, flags);
   }
 }
@@ -176,8 +186,8 @@ function onSessionHeaders(id, cat, flags, headers) {
 // there are trailing headers to send.
 function onSessionTrailers(id) {
   const owner = this._owner;
-  debug(`[${sessionName(owner.type)}] checking for trailers`);
-  const streams = owner._state.streams;
+  debug(`[${sessionName(owner[kType])}] checking for trailers`);
+  const streams = owner[kState].streams;
   const stream = streams.get(id);
   // It should not be possible for the stream not to exist at this point.
   // If it does not exist, there is something very very wrong.
@@ -205,19 +215,19 @@ function onSessionTrailers(id) {
 // Readable and Writable sides of the Duplex.
 function onSessionStreamClose(id, code) {
   const owner = this._owner;
-  debug(`[${sessionName(owner.type)}] session is closing the stream ` +
+  debug(`[${sessionName(owner[kType])}] session is closing the stream ` +
         `${id}: ${code}`);
-  const stream = owner._state.streams.get(id);
+  const stream = owner[kState].streams.get(id);
   if (stream === undefined)
     return;
   _unrefActive(this);
   // Set the rst state for the stream
   abort(stream);
-  stream._state.rst = true;
-  stream._state.rstCode = code;
+  stream[kState].rst = true;
+  stream[kState].rstCode = code;
   setImmediate(() => {
     stream.destroy();
-    debug(`[${sessionName(owner.type)}] stream ${id} is closed`);
+    debug(`[${sessionName(owner[kType])}] stream ${id} is closed`);
   });
 }
 
@@ -230,7 +240,7 @@ function onSessionError(error) {
 // Receives a chunk of data for a given stream and forwards it on
 // to the Http2Stream Duplex for processing.
 function onSessionRead(nread, buf, handle) {
-  const streams = this._owner._state.streams;
+  const streams = this._owner[kState].streams;
   const id = handle.id;
   const stream = streams.get(id);
   // It should not be possible for the stream to not exist at this point.
@@ -238,7 +248,7 @@ function onSessionRead(nread, buf, handle) {
   assert(stream !== undefined,
          'Internal HTTP/2 Failure. Stream does not exist. Please ' +
          'report this as a bug in Node.js');
-  const state = stream._state;
+  const state = stream[kState];
   _unrefActive(this); // Reset the session timeout timer
   _unrefActive(stream); // Reset the stream timout timer
   if (!stream.push(buf)) {
@@ -253,11 +263,11 @@ function onSessionRead(nread, buf, handle) {
 // Resets the cached settings.
 function onSettings(ack) {
   const owner = this._owner;
-  debug(`[${sessionName(owner.type)}] new settings received`);
+  debug(`[${sessionName(owner[kType])}] new settings received`);
   _unrefActive(this);
   if (ack) {
-    if (owner._state.pendingAck > 0)
-      owner._state.pendingAck--;
+    if (owner[kState].pendingAck > 0)
+      owner[kState].pendingAck--;
     owner[kLocalSettings] = undefined;
     owner.emit('localSettings', owner.localSettings);
   } else {
@@ -271,11 +281,11 @@ function onSettings(ack) {
 // session (which may, in turn, forward it on to the server)
 function onPriority(id, parent, weight, exclusive) {
   const owner = this._owner;
-  debug(`[${sessionName(owner.type)}] priority advisement for stream ` +
+  debug(`[${sessionName(owner[kType])}] priority advisement for stream ` +
         `${id}: \n  parent: ${parent},\n  weight: ${weight},\n` +
         `  exclusive: ${exclusive}`);
   _unrefActive(this);
-  const streams = owner._state.streams;
+  const streams = owner[kState].streams;
   const stream = streams.get(id);
   if (stream === undefined ||
       !stream.emit('priority', parent, weight, exclusive)) {
@@ -285,10 +295,10 @@ function onPriority(id, parent, weight, exclusive) {
 
 function onFrameError(id, type, code) {
   const owner = this._owner;
-  debug(`[${sessionName(owner.type)}] error sending frame type ` +
+  debug(`[${sessionName(owner[kType])}] error sending frame type ` +
         `${type} on stream ${id}, code: ${code}`);
   _unrefActive(this);
-  const streams = owner._state.streams;
+  const streams = owner[kState].streams;
   const stream = streams.get(id);
   if (stream !== undefined && stream.emit('frameError', type, code))
     return;
@@ -317,17 +327,17 @@ function onSelectPadding(fn) {
 
 // Called when the socket is connected to handle a pending request.
 function requestOnConnect(headers, options) {
-  const session = this.session;
-  debug(`[${sessionName(session.type)}] connected.. initializing request`);
-  const streams = session._state.streams;
+  const session = this[kSession];
+  debug(`[${sessionName(session[kType])}] connected.. initializing request`);
+  const streams = session[kState].streams;
   // ret will be either the reserved stream ID (if positive)
   // or an error code (if negative)
   validatePriorityOptions(options);
-  const ret = session._handle.submitRequest(mapToHeaders(headers),
-                                            !!options.endStream,
-                                            options.parent | 0,
-                                            options.weight | 0,
-                                            !!options.exclusive);
+  const ret = session[kHandle].submitRequest(mapToHeaders(headers),
+                                             !!options.endStream,
+                                             options.parent | 0,
+                                             options.weight | 0,
+                                             !!options.exclusive);
 
   // In an error condition, one of three possible response codes will be
   // possible:
@@ -360,7 +370,7 @@ function requestOnConnect(headers, options) {
         process.nextTick(() => session.emit('error', err));
         break;
       }
-      debug(`[${sessionName(session.type)}] stream ${ret} initialized`);
+      debug(`[${sessionName(session[kType])}] stream ${ret} initialized`);
       this[kInit](ret);
       streams.set(ret, this);
   }
@@ -412,7 +422,7 @@ function validatePriorityOptions(options) {
 function setupHandle(session, socket, type, options) {
   return function() {
     debug(`[${sessionName(type)}] setting up session handle`);
-    session._state.connecting = false;
+    session[kState].connecting = false;
 
     updateOptionsBuffer(options);
     const handle = new binding.Http2Session(type);
@@ -434,11 +444,7 @@ function setupHandle(session, socket, type, options) {
            'report this as a bug in Node.js');
     handle.consume(socket._handle._externalStream);
 
-    Object.defineProperty(session, '_handle', {
-      configurable: false,
-      enumerable: false,
-      value: handle
-    });
+    session[kHandle] = handle;
 
     const settings = typeof options.settings === 'object' ?
         options.settings : Object.create(null);
@@ -449,13 +455,13 @@ function setupHandle(session, socket, type, options) {
 }
 
 function submitSettings(settings) {
-  debug(`[${sessionName(this.type)}] submitting actual settings`);
+  debug(`[${sessionName(this[kType])}] submitting actual settings`);
   _unrefActive(this);
   this[kLocalSettings] = undefined;
 
   updateSettingsBuffer(settings);
 
-  const ret = this._handle.submitSettings();
+  const ret = this[kHandle].submitSettings();
   let err;
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
@@ -469,16 +475,16 @@ function submitSettings(settings) {
         process.nextTick(() => this.emit('error', err));
       }
   }
-  debug(`[${sessionName(this.type)}] settings complete`);
+  debug(`[${sessionName(this[kType])}] settings complete`);
 }
 
 function submitPriority(stream, options) {
-  debug(`[${sessionName(this.type)}] submitting actual priority`);
+  debug(`[${sessionName(this[kType])}] submitting actual priority`);
   _unrefActive(this);
 
   const ret =
-    this._handle.submitPriority(
-      stream.id,
+    this[kHandle].submitPriority(
+      stream[kID],
       options.parent | 0,
       options.weight | 0,
       !!options.exclusive,
@@ -497,14 +503,14 @@ function submitPriority(stream, options) {
         process.nextTick(() => this.emit('error', err));
       }
   }
-  debug(`[${sessionName(this.type)}] priority complete`);
+  debug(`[${sessionName(this[kType])}] priority complete`);
 }
 
 function submitRstStream(stream, code) {
-  debug(`[${sessionName(this.type)}] submit actual rststream`);
+  debug(`[${sessionName(this[kType])}] submit actual rststream`);
   _unrefActive(this);
-  const id = stream.id;
-  const ret = this._handle.submitRstStream(id, code);
+  const id = stream[kID];
+  const ret = this[kHandle].submitRstStream(id, code);
   let err;
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
@@ -520,30 +526,30 @@ function submitRstStream(stream, code) {
       }
       stream.destroy();
   }
-  debug(`[${sessionName(this.type)}] rststream complete`);
+  debug(`[${sessionName(this[kType])}] rststream complete`);
 }
 
 // Called when a requested session shutdown has been completed.
 function onSessionShutdownComplete(status, wrap) {
   const session = wrap._owner;
-  session._state.shuttingDown = false;
-  session._state.shutdown = true;
+  session[kState].shuttingDown = false;
+  session[kState].shutdown = true;
   process.nextTick(() => session.emit('shutdown', wrap.options));
   delete wrap._owner;
-  debug(`[${sessionName(session.type)}] shutdown is complete`);
+  debug(`[${sessionName(session[kType])}] shutdown is complete`);
 }
 
 function submitShutdown(options) {
-  debug(`[${sessionName(this.type)}] submitting actual shutdown request`);
+  debug(`[${sessionName(this[kType])}] submitting actual shutdown request`);
   const sessionShutdownWrap = new SessionShutdownWrap();
   sessionShutdownWrap.oncomplete = onSessionShutdownComplete;
   sessionShutdownWrap.options = options;
   sessionShutdownWrap._owner = this;
-  this._handle.submitShutdown(sessionShutdownWrap,
-                              !!options.graceful,
-                              options.errorCode | 0,
-                              options.lastStreamID | 0,
-                              options.opaqueData);
+  this[kHandle].submitShutdown(sessionShutdownWrap,
+                               !!options.graceful,
+                               options.errorCode | 0,
+                               options.lastStreamID | 0,
+                               options.opaqueData);
 }
 
 // Upon creation, the Http2Session takes ownership of the socket. The session
@@ -574,40 +580,22 @@ class Http2Session extends EventEmitter {
     // If the session property already exists on the socket,
     // then it has already been bound to an Http2Session instance
     // and cannot be attached again.
-    if (socket.session !== undefined)
+    if (socket[kSession] !== undefined)
       throw new errors.Error('ERR_HTTP2_SOCKET_BOUND');
 
-    // Bind the socket to the session
-    Object.defineProperty(socket, 'session', {
-      configurable: true,
-      enumerable: true,
-      value: this
-    });
+    socket[kSession] = this;
 
-    Object.defineProperties(this, {
-      _state: {
-        configurable: false,
-        enumerable: false,
-        value: {
-          streams: new Map(),
-          destroyed: false,
-          shutdown: false,
-          shuttingDown: false,
-          pendingAck: 0,
-          maxPendingAck: Math.max(1, (options.maxPendingAck | 0) || 10)
-        }
-      },
-      type: {
-        configurable: false,
-        enumerable: true,
-        value: type
-      },
-      socket: {
-        configurable: true,
-        enumerable: true,
-        value: socket
-      }
-    });
+    this[kState] = {
+      streams: new Map(),
+      destroyed: false,
+      shutdown: false,
+      shuttingDown: false,
+      pendingAck: 0,
+      maxPendingAck: Math.max(1, (options.maxPendingAck | 0) || 10)
+    };
+
+    this[kType] = type;
+    this[kSocket] = socket;
 
     // Do not use nagle's algorithm
     socket.setNoDelay();
@@ -621,7 +609,7 @@ class Http2Session extends EventEmitter {
 
     const setupFn = setupHandle(this, socket, type, options);
     if (socket.connecting) {
-      this._state.connecting = true;
+      this[kState].connecting = true;
       socket.once('connect', setupFn);
     } else {
       setupFn();
@@ -639,9 +627,9 @@ class Http2Session extends EventEmitter {
   }
 
   [kInspect](depth, opts) {
-    const state = this._state;
+    const state = this[kState];
     const obj = {
-      type: this.type,
+      type: this[kType],
       destroyed: state.destroyed,
       destroying: state.destroying,
       shutdown: state.shutdown,
@@ -653,16 +641,24 @@ class Http2Session extends EventEmitter {
     return `Http2Session ${util.format(obj)}`;
   }
 
+  get socket() {
+    return this[kSocket];
+  }
+
+  get type() {
+    return this[kType];
+  }
+
   get pendingSettingsAck() {
-    return this._state.pendingAck > 0;
+    return this[kState].pendingAck > 0;
   }
 
   get destroyed() {
-    return this._state.destroyed;
+    return this[kState].destroyed;
   }
 
   get state() {
-    const handle = this._handle;
+    const handle = this[kHandle];
     return handle !== undefined ?
       getSessionState(handle) :
       Object.create(null);
@@ -673,7 +669,7 @@ class Http2Session extends EventEmitter {
     if (settings !== undefined)
       return settings;
 
-    const handle = this._handle;
+    const handle = this[kHandle];
     if (handle === undefined)
       return Object.create(null);
 
@@ -687,7 +683,7 @@ class Http2Session extends EventEmitter {
     if (settings !== undefined)
       return settings;
 
-    const handle = this._handle;
+    const handle = this[kHandle];
     if (handle === undefined)
       return Object.create(null);
 
@@ -697,7 +693,7 @@ class Http2Session extends EventEmitter {
   }
 
   settings(settings) {
-    if (this._state.destroyed)
+    if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
 
     // Validate the input first
@@ -725,15 +721,15 @@ class Http2Session extends EventEmitter {
       err.actual = settings.enablePush;
       throw err;
     }
-    if (this._state.pendingAck === this._state.maxPendingAck) {
+    if (this[kState].pendingAck === this[kState].maxPendingAck) {
       throw new errors.Error('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
-                             this._state.pendingAck);
+                             this[kState].pendingAck);
     }
-    debug(`[${sessionName(this.type)}] sending settings`);
+    debug(`[${sessionName(this[kType])}] sending settings`);
 
-    this._state.pendingAck++;
-    if (this._state.connecting) {
-      debug(`[${sessionName(this.type)}] session still connecting, ` +
+    this[kState].pendingAck++;
+    if (this[kState].connecting) {
+      debug(`[${sessionName(this[kType])}] session still connecting, ` +
             'queue settings');
       this.once('connect', submitSettings.bind(this, settings));
       return;
@@ -742,7 +738,7 @@ class Http2Session extends EventEmitter {
   }
 
   priority(stream, options) {
-    if (this._state.destroyed)
+    if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
 
     if (!(stream instanceof Http2Stream)) {
@@ -754,19 +750,19 @@ class Http2Session extends EventEmitter {
     options = Object.assign(Object.create(null), options);
     validatePriorityOptions(options);
 
-    debug(`[${sessionName(this.type)}] sending priority for stream ` +
-          `${stream.id}`);
+    debug(`[${sessionName(this[kType])}] sending priority for stream ` +
+          `${stream[kID]}`);
 
     // A stream cannot be made to depend on itself
-    if (options.parent === stream.id) {
-      debug(`[${sessionName(this.type)}] session still connecting. queue ` +
+    if (options.parent === stream[kID]) {
+      debug(`[${sessionName(this[kType])}] session still connecting. queue ` +
             'priority');
       throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
                                  'parent',
                                  options.parent);
     }
 
-    if (this._state.connecting) {
+    if (this[kState].connecting) {
       this.once('connect', submitPriority.bind(this, stream, options));
       return;
     }
@@ -774,7 +770,7 @@ class Http2Session extends EventEmitter {
   }
 
   rstStream(stream, code) {
-    if (this._state.destroyed)
+    if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
 
     if (!(stream instanceof Http2Stream)) {
@@ -789,20 +785,20 @@ class Http2Session extends EventEmitter {
                                  'number');
     }
 
-    if (this._state.rst) {
+    if (this[kState].rst) {
       // rst has already been called, do not call again,
       // skip straight to destroy
       stream.destroy();
       return;
     }
-    stream._state.rst = true;
-    stream._state.rstCode = code;
+    stream[kState].rst = true;
+    stream[kState].rstCode = code;
 
-    debug(`[${sessionName(this.type)}] initiating rststream for stream ` +
-          `${stream.id}: ${code}`);
+    debug(`[${sessionName(this[kType])}] initiating rststream for stream ` +
+          `${stream[kID]}: ${code}`);
 
-    if (this._state.connecting) {
-      debug(`[${sessionName(this.type)}] session still connecting, queue ` +
+    if (this[kState].connecting) {
+      debug(`[${sessionName(this[kType])}] session still connecting, queue ` +
             'rststream');
       this.once('connect', submitRstStream.bind(this, stream, code));
       return;
@@ -811,11 +807,11 @@ class Http2Session extends EventEmitter {
   }
 
   destroy() {
-    const state = this._state;
+    const state = this[kState];
     if (state.destroyed || state.destroying)
       return;
 
-    debug(`[${sessionName(this.type)}] destroying nghttp2session`);
+    debug(`[${sessionName(this[kType])}] destroying nghttp2session`);
     state.destroying = true;
 
     // Unenroll the timer
@@ -826,10 +822,10 @@ class Http2Session extends EventEmitter {
     streams.forEach((stream) => stream.destroy());
 
     // Disassociate from the socket and server
-    const socket = this.socket;
+    const socket = this[kSocket];
     socket.pause();
-    delete this.socket;
-    delete this.server;
+    delete this[kSocket];
+    delete this[kServer];
 
     state.destroyed = true;
     state.destroying = false;
@@ -839,26 +835,26 @@ class Http2Session extends EventEmitter {
         socket.destroy();
 
       // Destroy the handle
-      const handle = this._handle;
+      const handle = this[kHandle];
       if (handle !== undefined) {
         handle.destroy();
-        debug(`[${sessionName(this.type)}] nghttp2session handle destroyed`);
+        debug(`[${sessionName(this[kType])}] nghttp2session handle destroyed`);
       }
 
       this.emit('close');
-      debug(`[${sessionName(this.type)}] nghttp2session destroyed`);
+      debug(`[${sessionName(this[kType])}] nghttp2session destroyed`);
     });
   }
 
   shutdown(options, callback) {
-    if (this._state.destroyed)
+    if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
 
-    if (this._state.shutdown || this._state.shuttingDown)
+    if (this[kState].shutdown || this[kState].shuttingDown)
       return;
 
-    debug(`[${sessionName(this.type)}] initiating shutdown`);
-    this._state.shuttingDown = true;
+    debug(`[${sessionName(this[kType])}] initiating shutdown`);
+    this[kState].shuttingDown = true;
 
     if (typeof options === 'function') {
       callback = options;
@@ -898,14 +894,14 @@ class Http2Session extends EventEmitter {
       this.on('shutdown', callback);
     }
 
-    if (this._state.connecting) {
-      debug(`[${sessionName(this.type)}] session still connecting, queue ` +
+    if (this[kState].connecting) {
+      debug(`[${sessionName(this[kType])}] session still connecting, queue ` +
             'shutdown');
       this.once('connect', submitShutdown.bind(this, options));
       return;
     }
 
-    debug(`[${sessionName(this.type)}] sending shutdown`);
+    debug(`[${sessionName(this[kType])}] sending shutdown`);
     submitShutdown.call(this, options);
   }
 
@@ -914,16 +910,27 @@ class Http2Session extends EventEmitter {
   }
 }
 
+class ServerHttp2Session extends Http2Session {
+  constructor(options, socket, server) {
+    super(NGHTTP2_SESSION_SERVER, options, socket);
+    this[kServer] = server;
+  }
+
+  get server() {
+    return this[kServer];
+  }
+}
+
 class ClientHttp2Session extends Http2Session {
   constructor(options, socket) {
     super(NGHTTP2_SESSION_CLIENT, options, socket);
-    debug(`[${sessionName(this.type)}] clienthttp2session created`);
+    debug(`[${sessionName(this[kType])}] clienthttp2session created`);
   }
 
   request(headers, options) {
-    if (this._state.destroyed)
+    if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
-    debug(`[${sessionName(this.type)}] initiating request`);
+    debug(`[${sessionName(this[kType])}] initiating request`);
     _unrefActive(this);
     assertIsObject(headers, 'headers');
     assertIsObject(options, 'options');
@@ -934,9 +941,9 @@ class ClientHttp2Session extends Http2Session {
     if (headers[HTTP2_HEADER_METHOD] === undefined)
       headers[HTTP2_HEADER_METHOD] = 'GET';
     if (headers[HTTP2_HEADER_AUTHORITY] === undefined)
-      headers[HTTP2_HEADER_AUTHORITY] = this._authority;
+      headers[HTTP2_HEADER_AUTHORITY] = this[kAuthority];
     if (headers[HTTP2_HEADER_SCHEME] === undefined)
-      headers[HTTP2_HEADER_SCHEME] = this._protocol.slice(0, -1);
+      headers[HTTP2_HEADER_SCHEME] = this[kProtocol].slice(0, -1);
     if (headers[HTTP2_HEADER_PATH] === undefined)
       headers[HTTP2_HEADER_PATH] = '/';
 
@@ -953,13 +960,13 @@ class ClientHttp2Session extends Http2Session {
     const stream = new ClientHttp2Stream(this, undefined, {});
     const onConnect = requestOnConnect.bind(stream, headers, options);
 
-    if (this._state.connecting) {
-      debug(`[${sessionName(this.type)}] session still connecting, queue ` +
+    if (this[kState].connecting) {
+      debug(`[${sessionName(this[kType])}] session still connecting, queue ` +
             'stream init');
       stream.on('connect', onConnect);
     } else {
-      debug(`[${sessionName(this.type)}] session connected, immediate stream ` +
-            'init');
+      debug(`[${sessionName(this[kType])}] session connected, immediate ` +
+            'stream init');
       onConnect();
     }
     return stream;
@@ -996,17 +1003,17 @@ function afterDoStreamWrite(status, handle, req) {
 }
 
 function onHandleFinish() {
-  const session = this.session;
+  const session = this[kSession];
   if (session === undefined) return;
-  if (this.id === undefined) {
+  if (this[kID] === undefined) {
     this.once('ready', onHandleFinish.bind(this));
   } else {
-    const handle = session._handle;
+    const handle = session[kHandle];
     if (handle !== undefined) {
       // Shutdown on the next tick of the event loop just in case there is
       // still data pending in the outbound queue.
-      assert(handle.shutdownStream(this.id) === undefined,
-             `The stream ${this.id} does not exist. Please report this as ` +
+      assert(handle.shutdownStream(this[kID]) === undefined,
+             `The stream ${this[kID]} does not exist. Please report this as ` +
              'a bug in Node.js');
     }
   }
@@ -1031,27 +1038,27 @@ function onStreamClosed(code) {
 function streamOnResume() {
   if (this._paused)
     return this.pause();
-  if (this.id === undefined) {
+  if (this[kID] === undefined) {
     this.once('ready', streamOnResume.bind(this));
     return;
   }
-  const session = this.session;
-  const state = this._state;
+  const session = this[kSession];
+  const state = this[kState];
   if (session && !state.reading) {
     state.reading = true;
-    assert(session._handle.streamReadStart(this.id) === undefined,
-           'HTTP/2 Stream #{this.id} does not exist. Please report this as ' +
+    assert(session[kHandle].streamReadStart(this[kID]) === undefined,
+           'HTTP/2 Stream #{this[kID]} does not exist. Please report this as ' +
            'a bug in Node.js');
   }
 }
 
 function streamOnPause() {
-  const session = this.session;
-  const state = this._state;
+  const session = this[kSession];
+  const state = this[kState];
   if (session && state.reading) {
     state.reading = false;
-    assert(session._handle.streamReadStop(this.id) === undefined,
-           `HTTP/2 Stream ${this.id} does not exist. Please report this as ' +
+    assert(session[kHandle].streamReadStop(this[kID]) === undefined,
+           `HTTP/2 Stream ${this[kID]} does not exist. Please report this as ' +
            'a bug in Node.js`);
   }
 }
@@ -1065,25 +1072,25 @@ function streamOnDrain() {
 }
 
 function streamOnSessionConnect() {
-  const session = this.session;
-  debug(`[${sessionName(session.type)}] session connected. emiting stream ` +
+  const session = this[kSession];
+  debug(`[${sessionName(session[kType])}] session connected. emiting stream ` +
         'connect');
-  this._state.connecting = false;
+  this[kState].connecting = false;
   this.emit('connect');
 }
 
 function streamOnceReady() {
-  const session = this.session;
-  debug(`[${sessionName(session.type)}] stream ${this.id} is ready`);
+  const session = this[kSession];
+  debug(`[${sessionName(session[kType])}] stream ${this[kID]} is ready`);
   this.uncork();
 }
 
 function abort(stream) {
-  if (!stream._state.aborted &&
+  if (!stream[kState].aborted &&
       stream._writableState &&
       !(stream._writableState.ended || stream._writableState.ending)) {
     stream.emit('aborted');
-    stream._state.aborted = true;
+    stream[kState].aborted = true;
   }
 }
 
@@ -1101,23 +1108,15 @@ class Http2Stream extends Duplex {
     options.allowHalfOpen = true;
     super(options);
     this.cork();
-    Object.defineProperties(this, {
-      _state: {
-        configurable: false,
-        enumerable: false,
-        value: {
-          rst: false,
-          rstCode: NGHTTP2_NO_ERROR,
-          headersSent: false,
-          aborted: false
-        }
-      },
-      session: {
-        configurable: true,
-        enumerable: true,
-        value: session
-      }
-    });
+    this[kSession] = session;
+
+    this[kState] = {
+      rst: false,
+      rstCode: NGHTTP2_NO_ERROR,
+      headersSent: false,
+      aborted: false
+    };
+
     this.once('ready', streamOnceReady);
     this.once('streamClosed', onStreamClosed);
     this.once('finish', onHandleFinish);
@@ -1126,27 +1125,23 @@ class Http2Stream extends Duplex {
     this.on('drain', streamOnDrain);
     session.once('close', onSessionClose.bind(this));
 
-    if (session._state.connecting) {
-      debug(`[${sessionName(session.type)}] session is still connecting, ` +
+    if (session[kState].connecting) {
+      debug(`[${sessionName(session[kType])}] session is still connecting, ` +
             'queuing stream init');
-      this._state.connecting = true;
+      this[kState].connecting = true;
       session.once('connect', streamOnSessionConnect.bind(this));
     }
-    debug(`[${sessionName(session.type)}] http2stream created`);
+    debug(`[${sessionName(session[kType])}] http2stream created`);
   }
 
   [kInit](id) {
-    Object.defineProperty(this, 'id', {
-      configurable: false,
-      enumerable: true,
-      value: id
-    });
+    this[kID] = id;
     this.emit('ready');
   }
 
   [kInspect](depth, opts) {
     const obj = {
-      id: this.id,
+      id: this[kID],
       state: this.state,
       readableState: this._readableState,
       writeableSate: this._writableState
@@ -1154,23 +1149,31 @@ class Http2Stream extends Duplex {
     return `Http2Stream ${util.format(obj)}`;
   }
 
+  get id() {
+    return this[kID];
+  }
+
+  get session() {
+    return this[kSession];
+  }
+
   _onTimeout() {
     this.emit('timeout');
   }
 
   get aborted() {
-    return this._state.aborted;
+    return this[kState].aborted;
   }
 
   get rstCode() {
-    return this._state.rst ? this._state.rstCode : undefined;
+    return this[kState].rst ? this[kState].rstCode : undefined;
   }
 
   get state() {
-    const id = this.id;
+    const id = this[kID];
     if (this.destroyed || id === undefined)
       return Object.create(null);
-    return getStreamState(this.session._handle, id);
+    return getStreamState(this[kSession][kHandle], id);
   }
 
   [kProceed]() {
@@ -1180,17 +1183,17 @@ class Http2Stream extends Duplex {
   }
 
   _write(data, encoding, cb) {
-    if (this.id === undefined) {
+    if (this[kID] === undefined) {
       this.once('ready', () => this._write(data, encoding, cb));
       return;
     }
     _unrefActive(this);
-    if (!this._state.headersSent)
+    if (!this[kState].headersSent)
       this[kProceed]();
-    const session = this.session;
-    const handle = session._handle;
+    const session = this[kSession];
+    const handle = session[kHandle];
     const req = new WriteWrap();
-    req.stream = this.id;
+    req.stream = this[kID];
     req.handle = handle;
     req.callback = cb;
     req.oncomplete = afterDoStreamWrite;
@@ -1203,17 +1206,17 @@ class Http2Stream extends Duplex {
   }
 
   _writev(data, cb) {
-    if (this.id === undefined) {
+    if (this[kID] === undefined) {
       this.once('ready', () => this._writev(data, cb));
       return;
     }
     _unrefActive(this);
-    if (!this._state.headersSent)
+    if (!this[kState].headersSent)
       this[kProceed]();
-    const session = this.session;
-    const handle = session._handle;
+    const session = this[kSession];
+    const handle = session[kHandle];
     const req = new WriteWrap();
-    req.stream = this.id;
+    req.stream = this[kID];
     req.handle = handle;
     req.callback = cb;
     req.oncomplete = afterDoStreamWrite;
@@ -1230,7 +1233,7 @@ class Http2Stream extends Duplex {
   }
 
   _read(nread) {
-    if (this.id === undefined) {
+    if (this[kID] === undefined) {
       this.once('ready', () => this._read(nread));
       return;
     }
@@ -1239,12 +1242,12 @@ class Http2Stream extends Duplex {
       return;
     }
     _unrefActive(this);
-    const state = this._state;
+    const state = this[kState];
     if (state.reading)
       return;
     state.reading = true;
-    assert(this.session._handle.streamReadStart(this.id) === undefined,
-           'HTTP/2 Stream #{this.id} does not exist. Please report this as ' +
+    assert(this[kSession][kHandle].streamReadStart(this[kID]) === undefined,
+           'HTTP/2 Stream #{this[kID]} does not exist. Please report this as ' +
            'a bug in Node.js');
   }
 
@@ -1256,16 +1259,17 @@ class Http2Stream extends Duplex {
   rstStream(code) {
     if (this.destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
-    const session = this.session;
-    if (this.id === undefined) {
-      debug(`[${sessionName(session.type)}] queuing rstStream for new stream`);
+    const session = this[kSession];
+    if (this[kID] === undefined) {
+      debug(
+        `[${sessionName(session[kType])}] queuing rstStream for new stream`);
       this.once('ready', () => this.rstStream(code));
       return;
     }
-    debug(`[${sessionName(session.type)}] sending rstStream for stream ` +
-          `${this.id}: ${code}`);
+    debug(`[${sessionName(session[kType])}] sending rstStream for stream ` +
+          `${this[kID]}: ${code}`);
     _unrefActive(this);
-    this.session.rstStream(this, code);
+    this[kSession].rstStream(this, code);
   }
 
   rstWithNoError() {
@@ -1297,16 +1301,16 @@ class Http2Stream extends Duplex {
   priority(options) {
     if (this.destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
-    const session = this.session;
-    if (this.id === undefined) {
-      debug(`[${sessionName(session.type)}] queuing priority for new stream`);
+    const session = this[kSession];
+    if (this[kID] === undefined) {
+      debug(`[${sessionName(session[kType])}] queuing priority for new stream`);
       this.once('ready', () => this.priority(options));
       return;
     }
-    debug(`[${sessionName(session.type)}] sending priority for stream ` +
-          `${this.id}`);
+    debug(`[${sessionName(session[kType])}] sending priority for stream ` +
+          `${this[kID]}`);
     _unrefActive(this);
-    this.session.priority(this, options);
+    this[kSession].priority(this, options);
   }
 
   // Called by this.destroy().
@@ -1316,37 +1320,37 @@ class Http2Stream extends Duplex {
   //   This will cause the internal resources to be released.
   // * Then cleans up the resources on the js side
   _destroy(err, callback) {
-    const session = this.session;
-    if (this.id === undefined) {
-      debug(`[${sessionName(session.type)}] queuing destroy for new stream`);
+    const session = this[kSession];
+    if (this[kID] === undefined) {
+      debug(`[${sessionName(session[kType])}] queuing destroy for new stream`);
       this.once('ready', this._destroy.bind(this, err, callback));
       return;
     }
-    debug(`[${sessionName(session.type)}] destroying stream ${this.id}`);
+    debug(`[${sessionName(session[kType])}] destroying stream ${this[kID]}`);
 
     // Submit RST-STREAM frame if one hasn't been sent already and the
     // stream hasn't closed normally...
-    if (!this._state.rst) {
+    if (!this[kState].rst) {
       const code =
         err instanceof Error ?
           NGHTTP2_INTERNAL_ERROR : NGHTTP2_NO_ERROR;
-      this.session.rstStream(this, code);
+      this[kSession].rstStream(this, code);
     }
 
     // Unenroll the timer
     unenroll(this);
 
     setImmediate(() => {
-      if (session._handle !== undefined)
-        session._handle.destroyStream(this.id);
+      if (session[kHandle] !== undefined)
+        session[kHandle].destroyStream(this[kID]);
     });
-    session._state.streams.delete(this.id);
-    delete this.session;
+    session[kState].streams.delete(this[kID]);
+    delete this[kSession];
 
     // All done
     this.emit('streamClosed',
-              this._state.rst ? this._state.rstCode : NGHTTP2_NO_ERROR);
-    debug(`[${sessionName(session.type)}] stream ${this.id} destroyed`);
+              this[kState].rst ? this[kState].rstCode : NGHTTP2_NO_ERROR);
+    debug(`[${sessionName(session[kType])}] stream ${this[kID]} destroyed`);
     callback(err);
   }
 }
@@ -1355,27 +1359,27 @@ class ServerHttp2Stream extends Http2Stream {
   constructor(session, id, options) {
     super(session, options);
     this[kInit](id);
-    debug(`[${sessionName(session.type)}] created serverhttp2stream`);
+    debug(`[${sessionName(session[kType])}] created serverhttp2stream`);
   }
 
   get pushAllowed() {
-    return this.session.remoteSettings.enablePush;
+    return this[kSession].remoteSettings.enablePush;
   }
 
   pushStream(headers, options, callback) {
     if (this.destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
 
-    const session = this.session;
-    debug(`[${sessionName(session.type)}] initiating push stream for stream ` +
-          `${this.id}`);
+    const session = this[kSession];
+    debug(`[${sessionName(session[kType])}] initiating push stream for stream` +
+          ` ${this[kID]}`);
 
     _unrefActive(this);
-    const state = session._state;
+    const state = session[kState];
     const streams = state.streams;
-    const handle = session._handle;
+    const handle = session[kHandle];
 
-    if (!this.session.remoteSettings.enablePush)
+    if (!this[kSession].remoteSettings.enablePush)
       throw new errors.Error('ERR_HTTP2_PUSH_DISABLED');
 
     if (typeof options === 'function') {
@@ -1396,13 +1400,13 @@ class ServerHttp2Stream extends Http2Stream {
     if (headers[HTTP2_HEADER_METHOD] === undefined)
       headers[HTTP2_HEADER_METHOD] = 'GET';
     if (headers[HTTP2_HEADER_AUTHORITY] === undefined)
-      headers[HTTP2_HEADER_AUTHORITY] = session._authority;
+      headers[HTTP2_HEADER_AUTHORITY] = session[kAuthority];
     if (headers[HTTP2_HEADER_SCHEME] === undefined)
-      headers[HTTP2_HEADER_SCHEME] = session._protocol.slice(0, -1);
+      headers[HTTP2_HEADER_SCHEME] = session[kProtocol].slice(0, -1);
     if (headers[HTTP2_HEADER_PATH] === undefined)
       headers[HTTP2_HEADER_PATH] = '/';
 
-    const ret = handle.submitPushPromise(this.id,
+    const ret = handle.submitPushPromise(this[kID],
                                          mapToHeaders(headers),
                                          options.endStream);
     let err;
@@ -1425,7 +1429,7 @@ class ServerHttp2Stream extends Http2Stream {
           process.nextTick(() => this.emit('error', err));
           break;
         }
-        debug(`[${sessionName(session.type)}] push stream ${ret} created`);
+        debug(`[${sessionName(session[kType])}] push stream ${ret} created`);
         options.readable = !options.endStream;
         const stream = new ServerHttp2Stream(session, ret, options);
         streams.set(ret, stream);
@@ -1434,13 +1438,13 @@ class ServerHttp2Stream extends Http2Stream {
   }
 
   respond(headers, options) {
-    const session = this.session;
+    const session = this[kSession];
     if (this.destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
-    debug(`[${sessionName(session.type)}] initiating response for stream ` +
-          `${this.id}`);
+    debug(`[${sessionName(session[kType])}] initiating response for stream ` +
+          `${this[kID]}`);
     _unrefActive(this);
-    const state = this._state;
+    const state = this[kState];
 
     assertIsObject(options, 'options');
     options = Object.assign(Object.create(null), options);
@@ -1473,15 +1477,15 @@ class ServerHttp2Stream extends Http2Stream {
       this.end();
 
     const ret =
-      this.session._handle.submitResponse(
-        this.id,
+      this[kSession][kHandle].submitResponse(
+        this[kID],
         mapToHeaders(headers, assertValidPseudoHeaderResponse),
         options.endStream);
     let err;
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        process.nextTick(() => this.session.emit('error', err));
+        process.nextTick(() => this[kSession].emit('error', err));
         break;
       default:
         if (ret < 0) {
@@ -1504,11 +1508,11 @@ class ServerHttp2Stream extends Http2Stream {
     if (this.destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
 
-    if (this._state.headersSent)
+    if (this[kState].headersSent)
       throw new errors.Error('ERR_HTTP2_HEADERS_AFTER_RESPOND');
 
-    const session = this.session;
-    debug(`[${sessionName(session.type)}] sending additional headers`);
+    const session = this[kSession];
+    debug(`[${sessionName(session[kType])}] sending additional headers`);
 
     assertIsObject(headers, 'headers');
     headers = Object.assign(Object.create(null), headers);
@@ -1521,16 +1525,16 @@ class ServerHttp2Stream extends Http2Stream {
     }
 
     _unrefActive(this);
-    const handle = this.session._handle;
+    const handle = this[kSession][kHandle];
     const ret =
-      handle.sendHeaders(this.id,
+      handle.sendHeaders(this[kID],
                          mapToHeaders(headers,
                                       assertValidPseudoHeaderResponse));
     let err;
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        process.nextTick(() => this.session.emit('error', err));
+        process.nextTick(() => this[kSession].emit('error', err));
         break;
       default:
         if (ret < 0) {
@@ -1546,10 +1550,10 @@ ServerHttp2Stream.prototype[kProceed] = ServerHttp2Stream.prototype.respond;
 class ClientHttp2Stream extends Http2Stream {
   constructor(session, id, options) {
     super(session, options);
-    this._state.headersSent = true;
+    this[kState].headersSent = true;
     if (id !== undefined)
       this[kInit](id);
-    debug(`[${sessionName(session.type)}] clienthttp2stream created`);
+    debug(`[${sessionName(session[kType])}] clienthttp2stream created`);
   }
 }
 
@@ -1605,12 +1609,12 @@ Object.defineProperties(Http2Session.prototype, {
 // Set as a replacement for socket.prototype.destroy upon the
 // establishment of a new connection.
 function socketDestroy(error) {
-  const type = this.session.type;
+  const type = this[kSession][kType];
   debug(`[${sessionName(type)}] socket destroy called`);
-  delete this.server;
+  delete this[kServer];
   // destroy the session first so that it will stop trying to
   // send data while we close the socket.
-  this.session.destroy();
+  this[kSession].destroy();
   this.destroy = this[kDestroySocket];
   debug(`[${sessionName(type)}] destroying the socket`);
   this.destroy(error);
@@ -1645,10 +1649,10 @@ function socketOnDrain() {
 // a sessionError; failing that, destroy, remove the error listener, and
 // re-emit the error event
 function sessionOnError(error) {
-  debug(`[${sessionName(this.type)}] server session error: ${error.message}`);
-  if (this.server !== undefined && this.server.emit('sessionError', error))
+  debug(`[${sessionName(this[kType])}] server session error: ${error.message}`);
+  if (this[kServer] !== undefined && this[kServer].emit('sessionError', error))
     return;
-  if (this.socket !== undefined && this.socket.emit('sessionError', error))
+  if (this[kSocket] !== undefined && this[kSocket].emit('sessionError', error))
     return;
   this.destroy();
   this.removeListener('error', sessionOnError);
@@ -1659,13 +1663,13 @@ function sessionOnError(error) {
 // as a socketError; failing that, forward it to the session as a
 // socketError; failing that, remove the listener and call destroy
 function socketOnError(error) {
-  const type = this.session && this.session.type;
+  const type = this[kSession] && this[kSession][kType];
   debug(`[${sessionName(type)}] server socket error: ${error.message}`);
   if (kRenegTest.test(error.message))
     return this.destroy();
-  if (this.server !== undefined && this.server.emit('socketError', error))
+  if (this[kServer] !== undefined && this[kServer].emit('socketError', error))
     return;
-  if (this.session !== undefined && this.session.emit('socketError', error))
+  if (this[kSession] !== undefined && this[kSession].emit('socketError', error))
     return;
   this.removeListener('error', socketOnError);
   this.destroy(error);
@@ -1675,10 +1679,10 @@ function socketOnError(error) {
 // of the session
 function socketOnTimeout() {
   debug('socket timeout');
-  const server = this.server;
+  const server = this[kServer];
   // server can be null if the socket is a client
   if (server === undefined || !server.emit('timeout', this)) {
-    this.session.shutdown(
+    this[kSession].shutdown(
       {
         graceful: true,
         errorCode: NGHTTP2_NO_ERROR
@@ -1690,18 +1694,18 @@ function socketOnTimeout() {
 // Handles the on('stream') event for a session and forwards
 // it on to the server object.
 function sessionOnStream(stream, headers, flags) {
-  debug(`[${sessionName(this.type)}] emit server stream event`);
-  this.server.emit('stream', stream, headers, flags);
+  debug(`[${sessionName(this[kType])}] emit server stream event`);
+  this[kServer].emit('stream', stream, headers, flags);
 }
 
 function sessionOnPriority(stream, parent, weight, exclusive) {
-  debug(`[${sessionName(this.type)}] priority change received`);
-  this.server.emit('priority', stream, parent, weight, exclusive);
+  debug(`[${sessionName(this[kType])}] priority change received`);
+  this[kServer].emit('priority', stream, parent, weight, exclusive);
 }
 
 function connectionListener(socket) {
   debug('server received a connection');
-  const options = this._options || {};
+  const options = this[kOptions] || {};
 
   if (this.timeout) {
     socket.setTimeout(this.timeout);
@@ -1727,19 +1731,14 @@ function connectionListener(socket) {
   socket.on('drain', socketOnDrain);
 
   // Set up the Session
-  const session = new Http2Session(NGHTTP2_SESSION_SERVER, options, socket);
+  const session = new ServerHttp2Session(options, socket, this);
 
   session.on('error', sessionOnError);
   session.on('stream', sessionOnStream);
   session.on('priority', sessionOnPriority);
 
-  const prop = {
-    configurable: true,
-    enumerable: true,
-    value: this
-  };
-  Object.defineProperty(session, 'server', prop);
-  Object.defineProperty(socket, 'server', prop);
+  socket[kServer] = this;
+
   process.nextTick(() => {
     this.emit('session', session);
   });
@@ -1773,11 +1772,7 @@ class Http2SecureServer extends TLSServer {
   constructor(options, requestListener) {
     options = initializeTLSOptions(options);
     super(options, connectionListener);
-    Object.defineProperty(this, '_options', {
-      configurable: false,
-      enumerable: false,
-      value: options
-    });
+    this[kOptions] = options;
     this.timeout = kDefaultSocketTimeout;
     this.on('newListener', setupCompat);
     if (typeof requestListener === 'function')
@@ -1800,11 +1795,7 @@ class Http2SecureServer extends TLSServer {
 class Http2Server extends NETServer {
   constructor(options, requestListener) {
     super(connectionListener);
-    Object.defineProperty(this, '_options', {
-      configurable: false,
-      enumerable: false,
-      value: initializeOptions(options)
-    });
+    this[kOptions] = initializeOptions(options);
     this.timeout = kDefaultSocketTimeout;
     this.on('newListener', setupCompat);
     if (typeof requestListener === 'function')
@@ -1834,11 +1825,11 @@ function setupCompat(ev) {
 // If the socket emits an error, forward it to the session as a socketError;
 // failing that, remove the listener and destroy the socket
 function clientSocketOnError(error) {
-  const type = this.session && this.session.type;
+  const type = this[kSession] && this[kSession][kType];
   debug(`[${sessionName(type)}] client socket error: ${error.message}`);
   if (kRenegTest.test(error.message))
     return this.destroy();
-  if (this.session !== undefined && this.session.emit('socketError', error))
+  if (this[kSession] !== undefined && this[kSession].emit('socketError', error))
     return;
   this.removeListener('error', clientSocketOnError);
   this.destroy(error);
@@ -1848,7 +1839,7 @@ function clientSocketOnError(error) {
 // failing that, destroy the session, remove the listener and re-emit the error
 function clientSessionOnError(error) {
   debug(`client session error: ${error.message}`);
-  if (this.socket !== undefined && this.socket.emit('sessionError', error))
+  if (this[kSocket] !== undefined && this[kSocket].emit('sessionError', error))
     return;
   this.destroy();
   this.removeListener('error', clientSocketOnError);
@@ -1896,18 +1887,8 @@ function connect(authority, options, listener) {
 
   session.on('error', clientSessionOnError);
 
-  Object.defineProperties(session, {
-    _authority: {
-      configurable: false,
-      enumerable: false,
-      value: `${host}:${port}`
-    },
-    _protocol: {
-      configurable: false,
-      enumerable: false,
-      value: protocol
-    }
-  });
+  session[kAuthority] = `${host}:${port}`;
+  session[kProtocol] = protocol;
 
   if (typeof listener === 'function')
     session.once('connect', listener);

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -38,7 +38,7 @@ const {
 } = require('timers');
 
 const { WriteWrap } = process.binding('stream_wrap');
-const { constants, SessionShutdownWrap } = binding;
+const { constants } = binding;
 
 const NETServer = net.Server;
 const TLSServer = tls.Server;
@@ -52,6 +52,7 @@ const kID = Symbol('id');
 const kInit = Symbol('init');
 const kLocalSettings = Symbol('local-settings');
 const kOptions = Symbol('options');
+const kOwner = Symbol('owner');
 const kProceed = Symbol('proceed');
 const kProtocol = Symbol('protocol');
 const kRemoteSettings = Symbol('remote-settings');
@@ -116,7 +117,7 @@ function sessionName(type) {
 // the block of headers on.
 function onSessionHeaders(id, cat, flags, headers) {
   _unrefActive(this);
-  const owner = this._owner;
+  const owner = this[kOwner];
   debug(`[${sessionName(owner[kType])}] headers were received on ` +
         `stream ${id}: ${cat}`);
   const streams = owner[kState].streams;
@@ -185,7 +186,7 @@ function onSessionHeaders(id, cat, flags, headers) {
 // is a necessarily synchronous operation. We need to know immediately if
 // there are trailing headers to send.
 function onSessionTrailers(id) {
-  const owner = this._owner;
+  const owner = this[kOwner];
   debug(`[${sessionName(owner[kType])}] checking for trailers`);
   const streams = owner[kState].streams;
   const stream = streams.get(id);
@@ -214,7 +215,7 @@ function onSessionTrailers(id) {
 // require('stream') interface 'close' event which deals with the state of the
 // Readable and Writable sides of the Duplex.
 function onSessionStreamClose(id, code) {
-  const owner = this._owner;
+  const owner = this[kOwner];
   debug(`[${sessionName(owner[kType])}] session is closing the stream ` +
         `${id}: ${code}`);
   const stream = owner[kState].streams.get(id);
@@ -234,13 +235,13 @@ function onSessionStreamClose(id, code) {
 // Called when an error event needs to be triggered
 function onSessionError(error) {
   _unrefActive(this);
-  this._owner.emit('error', error);
+  this[kOwner].emit('error', error);
 }
 
 // Receives a chunk of data for a given stream and forwards it on
 // to the Http2Stream Duplex for processing.
 function onSessionRead(nread, buf, handle) {
-  const streams = this._owner[kState].streams;
+  const streams = this[kOwner][kState].streams;
   const id = handle.id;
   const stream = streams.get(id);
   // It should not be possible for the stream to not exist at this point.
@@ -262,7 +263,7 @@ function onSessionRead(nread, buf, handle) {
 // Called when the remote peer settings have been updated.
 // Resets the cached settings.
 function onSettings(ack) {
-  const owner = this._owner;
+  const owner = this[kOwner];
   debug(`[${sessionName(owner[kType])}] new settings received`);
   _unrefActive(this);
   if (ack) {
@@ -280,7 +281,7 @@ function onSettings(ack) {
 // on the stream object itself. Otherwise, forward it on to the
 // session (which may, in turn, forward it on to the server)
 function onPriority(id, parent, weight, exclusive) {
-  const owner = this._owner;
+  const owner = this[kOwner];
   debug(`[${sessionName(owner[kType])}] priority advisement for stream ` +
         `${id}: \n  parent: ${parent},\n  weight: ${weight},\n` +
         `  exclusive: ${exclusive}`);
@@ -296,7 +297,7 @@ function onPriority(id, parent, weight, exclusive) {
 // Called by the native layer when an error has occurred sending a
 // frame. This should be exceedingly rare.
 function onFrameError(id, type, code) {
-  const owner = this._owner;
+  const owner = this[kOwner];
   debug(`[${sessionName(owner[kType])}] error sending frame type ` +
         `${type} on stream ${id}, code: ${code}`);
   _unrefActive(this);
@@ -432,7 +433,7 @@ function setupHandle(session, socket, type, options) {
 
     updateOptionsBuffer(options);
     const handle = new binding.Http2Session(type);
-    handle._owner = session;
+    handle[kOwner] = session;
     handle.onpriority = onPriority;
     handle.onsettings = onSettings;
     handle.onheaders = onSessionHeaders;
@@ -541,28 +542,38 @@ function submitRstStream(stream, code) {
   debug(`[${sessionName(this[kType])}] rststream complete`);
 }
 
-// Called when a requested session shutdown has been completed.
-function onSessionShutdownComplete(status, wrap) {
-  const session = wrap._owner;
-  session[kState].shuttingDown = false;
-  session[kState].shutdown = true;
-  process.nextTick(() => session.emit('shutdown', wrap.options));
-  delete wrap._owner;
-  debug(`[${sessionName(session[kType])}] shutdown is complete`);
+function doShutdown(options) {
+  const handle = this[kHandle];
+  const state = this[kState];
+  if (handle === undefined || state.shutdown)
+    return; // Nothing to do, possibly because the session shutdown already.
+  const ret = handle.submitGoaway(options.errorCode | 0,
+                                  options.lastStreamID | 0,
+                                  options.opaqueData);
+  state.shuttingDown = false;
+  state.shutdown = true;
+  if (ret < 0) {
+    debug(`[${sessionName(this[kType])}] shutdown failed! code: ${ret}`);
+    const err = new NghttpError(ret);
+    process.nextTick(() => this.emit('error', err));
+    return;
+  }
+  process.nextTick(() => this.emit('shutdown', options));
+  debug(`[${sessionName(this[kType])}] shutdown is complete`);
 }
 
 // Submit a graceful or immediate shutdown request for the Http2Session.
 function submitShutdown(options) {
   debug(`[${sessionName(this[kType])}] submitting actual shutdown request`);
-  const sessionShutdownWrap = new SessionShutdownWrap();
-  sessionShutdownWrap.oncomplete = onSessionShutdownComplete;
-  sessionShutdownWrap.options = options;
-  sessionShutdownWrap._owner = this;
-  this[kHandle].submitShutdown(sessionShutdownWrap,
-                               !!options.graceful,
-                               options.errorCode | 0,
-                               options.lastStreamID | 0,
-                               options.opaqueData);
+  const handle = this[kHandle];
+  if (options.graceful === true) {
+    // first send a shutdown notice
+    handle.submitShutdownNotice();
+    // then, on next tick, do the actual shutdown
+    setImmediate(doShutdown.bind(this, options));
+  } else {
+    doShutdown.call(this, options);
+  }
 }
 
 // Upon creation, the Http2Session takes ownership of the socket. The session
@@ -917,6 +928,13 @@ class Http2Session extends EventEmitter {
                                  options.lastStreamID);
     }
 
+    if (options.opaqueData !== undefined &&
+        !Buffer.isBuffer(options.opaqueData)) {
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
+                                 'opaqueData',
+                                 options.opaqueData);
+    }
+
     if (callback) {
       this.on('shutdown', callback);
     }
@@ -1025,7 +1043,7 @@ function createWriteReq(req, handle, data, encoding) {
 }
 
 function afterDoStreamWrite(status, handle, req) {
-  _unrefActive(handle._owner);
+  _unrefActive(handle[kOwner]);
   if (typeof req.callback === 'function')
     req.callback();
   this.handle = undefined;

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -250,7 +250,7 @@ function onSessionRead(nread, buf, handle) {
          'report this as a bug in Node.js');
   const state = stream[kState];
   _unrefActive(this); // Reset the session timeout timer
-  _unrefActive(stream); // Reset the stream timout timer
+  _unrefActive(stream); // Reset the stream timeout timer
   if (!stream.push(buf)) {
     assert(this.streamReadStop(id) === undefined,
            `HTTP/2 Stream ${id} does not exist. Please report this as ' +
@@ -293,6 +293,8 @@ function onPriority(id, parent, weight, exclusive) {
   }
 }
 
+// Called by the native layer when an error has occurred sending a
+// frame. This should be exceedingly rare.
 function onFrameError(id, type, code) {
   const owner = this._owner;
   debug(`[${sessionName(owner[kType])}] error sending frame type ` +
@@ -304,7 +306,6 @@ function onFrameError(id, type, code) {
     return;
   owner.emit('frameError', type, code, id);
 }
-
 
 // Returns the padding to use per frame. The selectPadding callback is set
 // on the options. It is invoked with two arguments, the frameLen, and the
@@ -325,7 +326,9 @@ function onSelectPadding(fn) {
   };
 }
 
-// Called when the socket is connected to handle a pending request.
+// When a ClientHttp2Session is first created, the socket may not yet be
+// connected. If request() is called during this time, the actual request
+// will be deferred until the socket is ready to go.
 function requestOnConnect(headers, options) {
   const session = this[kSession];
   debug(`[${sessionName(session[kType])}] connected.. initializing request`);
@@ -377,7 +380,6 @@ function requestOnConnect(headers, options) {
 }
 
 function validatePriorityOptions(options) {
-
   if (options.weight === undefined)
     options.weight = NGHTTP2_DEFAULT_WEIGHT;
   else if (typeof options.weight !== 'number') {
@@ -419,6 +421,10 @@ function validatePriorityOptions(options) {
   }
 }
 
+// Creates the internal binding.Http2Session handle for an Http2Session
+// instance. This occurs only after the socket connection has been
+// established. Note: the binding.Http2Session will take over ownership
+// of the socket. No other code should read from or write to the socket.
 function setupHandle(session, socket, type, options) {
   return function() {
     debug(`[${sessionName(type)}] setting up session handle`);
@@ -454,6 +460,7 @@ function setupHandle(session, socket, type, options) {
   };
 }
 
+// Submits a SETTINGS frame to be sent to the remote peer.
 function submitSettings(settings) {
   debug(`[${sessionName(this[kType])}] submitting actual settings`);
   _unrefActive(this);
@@ -478,6 +485,9 @@ function submitSettings(settings) {
   debug(`[${sessionName(this[kType])}] settings complete`);
 }
 
+// Submits a PRIORITY frame to be sent to the remote peer
+// Note: If the silent option is true, the change will be made
+// locally with no PRIORITY frame sent.
 function submitPriority(stream, options) {
   debug(`[${sessionName(this[kType])}] submitting actual priority`);
   _unrefActive(this);
@@ -506,6 +516,8 @@ function submitPriority(stream, options) {
   debug(`[${sessionName(this[kType])}] priority complete`);
 }
 
+// Submit an RST-STREAM frame to be sent to the remote peer.
+// This will cause the Http2Stream to be closed.
 function submitRstStream(stream, code) {
   debug(`[${sessionName(this[kType])}] submit actual rststream`);
   _unrefActive(this);
@@ -539,6 +551,7 @@ function onSessionShutdownComplete(status, wrap) {
   debug(`[${sessionName(session[kType])}] shutdown is complete`);
 }
 
+// Submit a graceful or immediate shutdown request for the Http2Session.
 function submitShutdown(options) {
   debug(`[${sessionName(this[kType])}] submitting actual shutdown request`);
   const sessionShutdownWrap = new SessionShutdownWrap();
@@ -641,22 +654,27 @@ class Http2Session extends EventEmitter {
     return `Http2Session ${util.format(obj)}`;
   }
 
+  // The socket owned by this session
   get socket() {
     return this[kSocket];
   }
 
+  // The session type
   get type() {
     return this[kType];
   }
 
+  // true if the Http2Session is waiting for a settings acknowledgement
   get pendingSettingsAck() {
     return this[kState].pendingAck > 0;
   }
 
+  // true if the Http2Session has been destroyed
   get destroyed() {
     return this[kState].destroyed;
   }
 
+  // Retrieves state information for the Http2Session
   get state() {
     const handle = this[kHandle];
     return handle !== undefined ?
@@ -664,6 +682,8 @@ class Http2Session extends EventEmitter {
       Object.create(null);
   }
 
+  // The settings currently in effect for the local peer. These will
+  // be updated only when a settings acknowledgement has been received.
   get localSettings() {
     let settings = this[kLocalSettings];
     if (settings !== undefined)
@@ -678,6 +698,7 @@ class Http2Session extends EventEmitter {
     return settings;
   }
 
+  // The settings currently in effect for the remote peer.
   get remoteSettings() {
     let settings = this[kRemoteSettings];
     if (settings !== undefined)
@@ -692,6 +713,7 @@ class Http2Session extends EventEmitter {
     return settings;
   }
 
+  // Submits a SETTINGS frame to be sent to the remote peer.
   settings(settings) {
     if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
@@ -737,6 +759,7 @@ class Http2Session extends EventEmitter {
     submitSettings.call(this, settings);
   }
 
+  // Submits a PRIORITY frame to be sent to the remote peer.
   priority(stream, options) {
     if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
@@ -769,6 +792,8 @@ class Http2Session extends EventEmitter {
     submitPriority.call(this, stream, options);
   }
 
+  // Submits an RST-STREAM frame to be sent to the remote peer. This will
+  // cause the stream to be closed.
   rstStream(stream, code) {
     if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
@@ -806,6 +831,7 @@ class Http2Session extends EventEmitter {
     submitRstStream.call(this, stream, code);
   }
 
+  // Destroy the Http2Session
   destroy() {
     const state = this[kState];
     if (state.destroyed || state.destroying)
@@ -846,6 +872,7 @@ class Http2Session extends EventEmitter {
     });
   }
 
+  // Graceful or immediate shutdown of the Http2Session
   shutdown(options, callback) {
     if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
@@ -927,6 +954,8 @@ class ClientHttp2Session extends Http2Session {
     debug(`[${sessionName(this[kType])}] clienthttp2session created`);
   }
 
+  // Submits a new HTTP2 request to the connected peer. Returns the
+  // associated Http2Stream instance.
   request(headers, options) {
     if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
@@ -1094,12 +1123,8 @@ function abort(stream) {
   }
 }
 
-// An Http2Stream is essentially a Duplex stream. It has a Readable side
-// and a Writable side. On the server-side, the Readable side provides
-// access to the received request data. The `headers` event is used to
-// notify when a new block of headers has been received, including those
-// that carry the request headers. At least one `headers` event should
-// trigger before any other events on the stream. On the client-side, the
+// An Http2Stream is a Duplex stream. On the server-side, the Readable side
+// provides access to the received request data. On the client-side, the
 // Readable side provides access to the received response data. On the
 // server side, the writable side is used to transmit response data, while
 // on the client side it is used to transmit request data.
@@ -1149,10 +1174,13 @@ class Http2Stream extends Duplex {
     return `Http2Stream ${util.format(obj)}`;
   }
 
+  // The id of the Http2Stream, will be undefined if the socket is not
+  // yet connected.
   get id() {
     return this[kID];
   }
 
+  // The Http2Session that owns this Http2Stream.
   get session() {
     return this[kSession];
   }
@@ -1161,14 +1189,17 @@ class Http2Stream extends Duplex {
     this.emit('timeout');
   }
 
+  // true if the Http2Stream was aborted abornomally.
   get aborted() {
     return this[kState].aborted;
   }
 
+  // The error code reported when this Http2Stream was closed.
   get rstCode() {
     return this[kState].rst ? this[kState].rstCode : undefined;
   }
 
+  // State information for the Http2Stream
   get state() {
     const id = this[kID];
     if (this.destroyed || id === undefined)
@@ -1362,10 +1393,13 @@ class ServerHttp2Stream extends Http2Stream {
     debug(`[${sessionName(session[kType])}] created serverhttp2stream`);
   }
 
+  // true if the remote peer accepts push streams
   get pushAllowed() {
     return this[kSession].remoteSettings.enablePush;
   }
 
+  // create a push stream, call the given callback with the created
+  // Http2Stream for the push stream.
   pushStream(headers, options, callback) {
     if (this.destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
@@ -1437,6 +1471,7 @@ class ServerHttp2Stream extends Http2Stream {
     }
   }
 
+  // Initiate a response on this Http2Stream
   respond(headers, options) {
     const session = this[kSession];
     if (this.destroyed)

--- a/lib/internal/module.js
+++ b/lib/internal/module.js
@@ -78,10 +78,14 @@ function stripShebang(content) {
 
 const builtinLibs = [
   'assert', 'async_hooks', 'buffer', 'child_process', 'cluster', 'crypto',
-  'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'http2', 'https', 'net',
+  'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https', 'net',
   'os', 'path', 'punycode', 'querystring', 'readline', 'repl', 'stream',
   'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'
 ];
+
+const { exposeHTTP2 } = process.binding('config');
+if (exposeHTTP2)
+  builtinLibs.push('http2');
 
 function addBuiltinLibsToObject(object) {
   // Make built-in modules available directly (loaded lazily).

--- a/src/node.cc
+++ b/src/node.cc
@@ -233,6 +233,9 @@ std::string config_warning_file;  // NOLINT(runtime/string)
 // that is used by lib/internal/bootstrap_node.js
 bool config_expose_internals = false;
 
+// Set in node.cc by ParseArgs when --expose-http2 is used.
+bool config_expose_http2 = false;
+
 bool v8_initialized = false;
 
 bool linux_at_secure = false;
@@ -3650,6 +3653,7 @@ static void PrintHelp() {
          "  --pending-deprecation      emit pending deprecation warnings\n"
          "  --no-warnings              silence all process warnings\n"
          "  --napi-modules             load N-API modules\n"
+         "  --expose-http2             enable experimental HTTP2 support\n"
          "  --trace-warnings           show stack traces on process warnings\n"
          "  --redirect-warnings=file\n"
          "                             write warnings to file instead of\n"
@@ -3751,6 +3755,7 @@ static void CheckIfAllowedInEnv(const char* exe, bool is_env,
     "--throw-deprecation",
     "--no-warnings",
     "--napi-modules",
+    "--expose-http2",
     "--trace-warnings",
     "--redirect-warnings",
     "--trace-sync-io",
@@ -3947,6 +3952,9 @@ static void ParseArgs(int* argc,
     } else if (strcmp(arg, "--expose-internals") == 0 ||
                strcmp(arg, "--expose_internals") == 0) {
       config_expose_internals = true;
+    } else if (strcmp(arg, "--expose-http2") == 0 ||
+               strcmp(arg, "--expose_http2") == 0) {
+      config_expose_http2 = true;
     } else if (strcmp(arg, "-") == 0) {
       break;
     } else if (strcmp(arg, "--") == 0) {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -88,6 +88,9 @@ static void InitConfig(Local<Object> target,
 
   if (config_expose_internals)
     READONLY_BOOLEAN_PROPERTY("exposeInternals");
+
+  if (config_expose_http2)
+    READONLY_BOOLEAN_PROPERTY("exposeHTTP2");
 }  // InitConfig
 
 }  // namespace node

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -83,6 +83,9 @@ extern std::string openssl_config;
 // that is used by lib/module.js
 extern bool config_preserve_symlinks;
 
+// Set in node.cc by ParseArgs when --expose-http2 is used.
+extern bool config_expose_http2;
+
 // Set in node.cc by ParseArgs when --expose-internals or --expose_internals is
 // used.
 // Used in node_config.cc to set a constant on process.binding('config')

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 require('../common');

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -11,9 +11,7 @@ const binding = process.binding('http2');
 const http2 = require('http2');
 
 assert(binding.Http2Session);
-assert(binding.SessionShutdownWrap);
 assert.strictEqual(typeof binding.Http2Session, 'function');
-assert.strictEqual(typeof binding.SessionShutdownWrap, 'function');
 
 const settings = http2.getDefaultSettings();
 assert.strictEqual(settings.headerTableSize, 4096);

--- a/test/parallel/test-http2-client-data-end.js
+++ b/test/parallel/test-http2-client-data-end.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-destroy-before-connect.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-destroy-before-request.js
+++ b/test/parallel/test-http2-client-destroy-before-request.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-priority-before-connect.js
+++ b/test/parallel/test-http2-client-priority-before-connect.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-rststream-before-connect.js
+++ b/test/parallel/test-http2-client-rststream-before-connect.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-set-priority.js
+++ b/test/parallel/test-http2-client-set-priority.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-settings-before-connect.js
+++ b/test/parallel/test-http2-client-settings-before-connect.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-shutdown-before-connect.js
+++ b/test/parallel/test-http2-client-shutdown-before-connect.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-socket-destroy.js
+++ b/test/parallel/test-http2-client-socket-destroy.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-stream-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-stream-destroy-before-connect.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-client-write-before-connect.js
+++ b/test/parallel/test-http2-client-write-before-connect.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverrequest.js
+++ b/test/parallel/test-http2-compat-serverrequest.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-finished.js
+++ b/test/parallel/test-http2-compat-serverresponse-finished.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-flushheaders.js
+++ b/test/parallel/test-http2-compat-serverresponse-flushheaders.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-statuscode.js
+++ b/test/parallel/test-http2-compat-serverresponse-statuscode.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-write-no-cb.js
+++ b/test/parallel/test-http2-compat-serverresponse-write-no-cb.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-compat-serverresponse-writehead.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-cookies.js
+++ b/test/parallel/test-http2-cookies.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-create-client-connect.js
+++ b/test/parallel/test-http2-create-client-connect.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 // Tests http2.connect()

--- a/test/parallel/test-http2-create-client-connect.js
+++ b/test/parallel/test-http2-create-client-connect.js
@@ -41,9 +41,7 @@ const URL = url.URL;
     });
 
     // Will fail because protocol does not match the server.
-    // Note, however, that the connect event will still fire
     h2.connect({port: port, protocol: 'https:'})
-      .on('connect', common.mustCall())
       .on('socketError', common.mustCall());
   }));
 }

--- a/test/parallel/test-http2-create-client-secure-session.js
+++ b/test/parallel/test-http2-create-client-secure-session.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-create-client-session.js
+++ b/test/parallel/test-http2-create-client-session.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const {

--- a/test/parallel/test-http2-https-fallback.js
+++ b/test/parallel/test-http2-https-fallback.js
@@ -4,8 +4,7 @@
 const {
   fixturesDir,
   mustCall,
-  mustNotCall,
-  platformTimeout
+  mustNotCall
 } = require('../common');
 const { strictEqual } = require('assert');
 const { join } = require('path');
@@ -17,17 +16,6 @@ const { parse } = require('url');
 const { connect: tls } = require('tls');
 
 const countdown = (count, done) => () => --count === 0 && done();
-
-function expire(callback, ttl) {
-  const timeout = setTimeout(
-    mustNotCall('Callback expired'),
-    platformTimeout(ttl)
-  );
-  return function expire() {
-    clearTimeout(timeout);
-    return callback();
-  };
-}
 
 function loadKey(keyname) {
   return readFileSync(join(fixturesDir, 'keys', keyname));
@@ -153,6 +141,6 @@ function onSession(session) {
 
     // Incompatible ALPN TLS client
     tls(Object.assign({ port, ALPNProtocols: ['fake'] }, clientOptions))
-      .on('error', expire(mustCall(cleanup), 200));
+      .on('error', mustCall(cleanup));
   }));
 }

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-max-concurrent-streams.js
+++ b/test/parallel/test-http2-max-concurrent-streams.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-methods.js
+++ b/test/parallel/test-http2-methods.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-misused-pseudoheaders.js
+++ b/test/parallel/test-http2-misused-pseudoheaders.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-noflag.js
+++ b/test/parallel/test-http2-noflag.js
@@ -1,0 +1,8 @@
+// The --expose-http2 flag is not set
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.throws(() => require('http2'),
+              /^Error: Cannot find module 'http2'$/);

--- a/test/parallel/test-http2-options-max-headers-block-length.js
+++ b/test/parallel/test-http2-options-max-headers-block-length.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-options-max-reserved-streams.js
+++ b/test/parallel/test-http2-options-max-reserved-streams.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-padding-callback.js
+++ b/test/parallel/test-http2-padding-callback.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-priority-event.js
+++ b/test/parallel/test-http2-priority-event.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-additional.js
+++ b/test/parallel/test-http2-server-destroy-before-additional.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-push.js
+++ b/test/parallel/test-http2-server-destroy-before-push.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-respond.js
+++ b/test/parallel/test-http2-server-destroy-before-respond.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-destroy-before-write.js
+++ b/test/parallel/test-http2-server-destroy-before-write.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-push-disabled.js
+++ b/test/parallel/test-http2-server-push-disabled.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-push-stream.js
+++ b/test/parallel/test-http2-server-push-stream.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-rst-before-respond.js
+++ b/test/parallel/test-http2-server-rst-before-respond.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-rst-stream.js
+++ b/test/parallel/test-http2-server-rst-stream.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-set-header.js
+++ b/test/parallel/test-http2-server-set-header.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-shutdown-before-respond.js
+++ b/test/parallel/test-http2-server-shutdown-before-respond.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-socket-destroy.js
+++ b/test/parallel/test-http2-server-socket-destroy.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-server-startup.js
+++ b/test/parallel/test-http2-server-startup.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 // Tests the basic operation of creating a plaintext or TLS

--- a/test/parallel/test-http2-server-startup.js
+++ b/test/parallel/test-http2-server-startup.js
@@ -44,10 +44,8 @@ assert.doesNotThrow(() => {
 // Test the plaintext server socket timeout
 {
   let client;
-  let timer;
-  const server = http2.createServer({}, common.noop);
+  const server = http2.createServer();
   server.on('timeout', common.mustCall(() => {
-    clearTimeout(timer);
     server.close();
     if (client)
       client.end();
@@ -57,17 +55,13 @@ assert.doesNotThrow(() => {
     const port = server.address().port;
     client = net.connect(port, common.mustCall());
   }));
-  timer = setTimeout(() => assert.fail('server timeout failed'),
-                     common.platformTimeout(1100));
 }
 
 // Test the secure server socket timeout
 {
   let client;
-  let timer;
-  const server = http2.createSecureServer(options, common.noop);
+  const server = http2.createSecureServer(options);
   server.on('timeout', common.mustCall(() => {
-    clearTimeout(timer);
     server.close();
     if (client)
       client.end();
@@ -81,6 +75,4 @@ assert.doesNotThrow(() => {
       ALPNProtocols: ['h2']
     }, common.mustCall());
   }));
-  timer = setTimeout(() => assert.fail('server timeout failed'),
-                     common.platformTimeout(1100));
 }

--- a/test/parallel/test-http2-session-settings.js
+++ b/test/parallel/test-http2-session-settings.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-session-stream-state.js
+++ b/test/parallel/test-http2-session-stream-state.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-timeouts.js
+++ b/test/parallel/test-http2-timeouts.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-too-many-settings.js
+++ b/test/parallel/test-http2-too-many-settings.js
@@ -37,7 +37,7 @@ const closeServer = common.mustCall(() => {
 server.on('listening', common.mustCall(() => {
   const client = h2.connect(`http://localhost:${server.address().port}`,
                             { maxPendingAck: maxPendingAck + 1 });
-  let remaining = maxPendingAck;
+  let remaining = maxPendingAck + 1;
 
   client.on('close', closeServer);
   client.on('localSettings', common.mustCall(() => {

--- a/test/parallel/test-http2-too-many-settings.js
+++ b/test/parallel/test-http2-too-many-settings.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 // Tests that attempting to send too many non-acknowledged

--- a/test/parallel/test-http2-trailers.js
+++ b/test/parallel/test-http2-trailers.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-util-asserts.js
+++ b/test/parallel/test-http2-util-asserts.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --expose-internals --expose-http2
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-http2-util-headers-list.js
+++ b/test/parallel/test-http2-util-headers-list.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --expose-internals --expose-http2
 'use strict';
 
 // Tests the internal utility function that is used to prepare headers

--- a/test/parallel/test-http2-window-size.js
+++ b/test/parallel/test-http2-window-size.js
@@ -80,7 +80,8 @@ const bufferValueRange = [0, 1, 2, 3];
 const buffersList = [
   bufferValueRange.map((a) => Buffer.alloc(1 << 4, a)),
   bufferValueRange.map((a) => Buffer.alloc((1 << 8) - 1, a)),
-  bufferValueRange.map((a) => Buffer.alloc(1 << 17, a))
+// Specifying too large of a value causes timeouts on some platforms
+//  bufferValueRange.map((a) => Buffer.alloc(1 << 17, a))
 ];
 const initialWindowSizeList = [
   1 << 4,

--- a/test/parallel/test-http2-window-size.js
+++ b/test/parallel/test-http2-window-size.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 // This test ensures that servers are able to send data independent of window

--- a/test/parallel/test-http2-withflag.js
+++ b/test/parallel/test-http2-withflag.js
@@ -1,0 +1,7 @@
+// Flags: --expose-http2
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.doesNotThrow(() => require('http2'));

--- a/test/parallel/test-http2-write-empty-string.js
+++ b/test/parallel/test-http2-write-empty-string.js
@@ -1,3 +1,4 @@
+// Flags: --expose-http2
 'use strict';
 
 const common = require('../common');


### PR DESCRIPTION
* Revert back to getters to avoid perf penalty with defineProperty (I had hoped defineProperty would be faster under TF-I... it isn't)

* Miscellaneous updates

* Introduce the `--expose-http2` command line argument

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2