### PR TITLE
http2: session shutdown improvements

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -125,6 +125,20 @@ closed and destroyed immediately following the `'frameError'` event. If the
 event is not associated with a stream, the `Http2Session` will be shutdown
 immediately following the `'frameError'` event.
 
+#### Event: 'goaway'
+
+The `'goaway'` event is emitted when a GOAWAY frame is received. When invoked,
+the handler function will receive three arguments:
+
+* `errorCode` {number} The HTTP/2 error code specified in the GOAWAY frame.
+* `lastStreamID` {number} The ID of the last stream the remote peer successfully
+  processed (or `0` if no ID is specified).
+* `opaqueData` {Buffer} If additional opaque data was included in the GOAWAY
+  frame, a `Buffer` instance will be passed containing that data.
+
+*Note*: The `Http2Session` instance will be shutdown automatically when the
+`'goaway'` event is emitted.
+
 #### Event: 'localSettings'
 
 The `'localSettings'` event is emitted when an acknowledgement SETTINGS frame

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -308,6 +308,14 @@ function onFrameError(id, type, code) {
   owner.emit('frameError', type, code, id);
 }
 
+// Called by the native layer when opaque data has been returned in a
+// GOAWAY frame
+function onGoawayData(code, lastStreamID, buf) {
+  const owner = this[kOwner];
+  debug(`[${sessionName(owner[kType])}] opaque goaway data received`);
+  owner.emit('goaway', code, lastStreamID, buf);
+}
+
 // Returns the padding to use per frame. The selectPadding callback is set
 // on the options. It is invoked with two arguments, the frameLen, and the
 // maxPayloadLen. The method must return a numeric value within the range
@@ -442,6 +450,7 @@ function setupHandle(session, socket, type, options) {
     handle.onerror = onSessionError;
     handle.onread = onSessionRead;
     handle.onframeerror = onFrameError;
+    handle.ongoawaydata = onGoawayData;
 
     if (typeof options.selectPadding === 'function')
       handle.ongetpadding = onSelectPadding(options.selectPadding);
@@ -576,6 +585,10 @@ function submitShutdown(options) {
   }
 }
 
+function onSessionGoaway(code, lastStreamID, buf) {
+  this.destroy();
+}
+
 // Upon creation, the Http2Session takes ownership of the socket. The session
 // may not be ready to use immediately if the socket is not yet fully connected.
 class Http2Session extends EventEmitter {
@@ -638,6 +651,8 @@ class Http2Session extends EventEmitter {
     } else {
       setupFn();
     }
+
+    this.on('goaway', onSessionGoaway);
 
     // Any individual session can have any number of active open
     // streams, these may all need to be made aware of changes

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -308,12 +308,19 @@ function onFrameError(id, type, code) {
   owner.emit('frameError', type, code, id);
 }
 
-// Called by the native layer when opaque data has been returned in a
-// GOAWAY frame
+// Called by the native layer when a goaway frame has been received
 function onGoawayData(code, lastStreamID, buf) {
   const owner = this[kOwner];
-  debug(`[${sessionName(owner[kType])}] opaque goaway data received`);
-  owner.emit('goaway', code, lastStreamID, buf);
+  const state = owner[kState];
+  debug(`[${sessionName(owner[kType])}] goaway data received`);
+  process.nextTick(() => owner.emit('goaway', code, lastStreamID, buf));
+  // Begin tearing down the session. If we have not yet sent a GOAWAY,
+  // attempt to do so. After, destroy the session.
+  if (!state.shuttingDown && !state.shutdown) {
+    owner.shutdown({}, () => { owner.destroy(); });
+  } else {
+    owner.destroy();
+  }
 }
 
 // Returns the padding to use per frame. The selectPadding callback is set
@@ -587,11 +594,6 @@ function submitShutdown(options) {
   }
 }
 
-function onSessionGoaway(code, lastStreamID, buf) {
-  // TODO(jasnell): What to do with code and lastStreamID
-  this.destroy();
-}
-
 // Upon creation, the Http2Session takes ownership of the socket. The session
 // may not be ready to use immediately if the socket is not yet fully connected.
 class Http2Session extends EventEmitter {
@@ -654,8 +656,6 @@ class Http2Session extends EventEmitter {
     } else {
       setupFn();
     }
-
-    this.on('goaway', onSessionGoaway);
 
     // Any individual session can have any number of active open
     // streams, these may all need to be made aware of changes

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -575,7 +575,9 @@ function doShutdown(options) {
 function submitShutdown(options) {
   debug(`[${sessionName(this[kType])}] submitting actual shutdown request`);
   const handle = this[kHandle];
-  if (options.graceful === true) {
+  const type = this[kType];
+  if (type === NGHTTP2_SESSION_SERVER &&
+      options.graceful === true) {
     // first send a shutdown notice
     handle.submitShutdownNotice();
     // then, on next tick, do the actual shutdown
@@ -586,6 +588,7 @@ function submitShutdown(options) {
 }
 
 function onSessionGoaway(code, lastStreamID, buf) {
+  // TODO(jasnell): What to do with code and lastStreamID
   this.destroy();
 }
 
@@ -898,7 +901,8 @@ class Http2Session extends EventEmitter {
     });
   }
 
-  // Graceful or immediate shutdown of the Http2Session
+  // Graceful or immediate shutdown of the Http2Session. Graceful shutdown
+  // is only supported on the server-side
   shutdown(options, callback) {
     if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
@@ -908,6 +912,8 @@ class Http2Session extends EventEmitter {
 
     debug(`[${sessionName(this[kType])}] initiating shutdown`);
     this[kState].shuttingDown = true;
+
+    const type = this[kType];
 
     if (typeof options === 'function') {
       callback = options;
@@ -923,7 +929,8 @@ class Http2Session extends EventEmitter {
                                  'opaqueData',
                                  options.opaqueData);
     }
-    if (options.graceful !== undefined &&
+    if (type === NGHTTP2_SESSION_SERVER &&
+        options.graceful !== undefined &&
         typeof options.graceful !== 'boolean') {
       throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
                                  'graceful',

--- a/src/env.h
+++ b/src/env.h
@@ -197,6 +197,7 @@ namespace node {
   V(onnewsession_string, "onnewsession")                                      \
   V(onnewsessiondone_string, "onnewsessiondone")                              \
   V(onocspresponse_string, "onocspresponse")                                  \
+  V(ongoawaydata_string, "ongoawaydata")                                      \
   V(onpriority_string, "onpriority")                                          \
   V(onread_string, "onread")                                                  \
   V(onreadstart_string, "onreadstart")                                        \

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -341,6 +341,10 @@ class Http2Session : public AsyncWrap,
                   int32_t parent,
                   int32_t weight,
                   int8_t exclusive) override;
+  void OnGoAway(int32_t lastStreamID,
+                uint32_t errorCode,
+                uint8_t* data,
+                size_t length) override;
   void OnFrameError(int32_t id, uint8_t type, int error_code) override;
   void OnTrailers(Nghttp2Stream* stream,
                   MaybeStackBuffer<nghttp2_nv>* trailers) override;

--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -118,6 +118,17 @@ inline void Nghttp2Session::HandlePriorityFrame(const nghttp2_frame* frame) {
   }
 }
 
+// Notifies the JS layer that a GOAWAY opaque data has been received
+inline void Nghttp2Session::HandleGoawayFrame(const nghttp2_frame* frame) {
+  nghttp2_goaway goaway_frame = frame->goaway;
+  DEBUG_HTTP2("Nghttp2Session %d: handling goaway frame\n", session_type_);
+
+  OnGoAway(goaway_frame.last_stream_id,
+            goaway_frame.error_code,
+            goaway_frame.opaque_data,
+            goaway_frame.opaque_data_len);
+}
+
 // Prompts nghttp2 to flush the queue of pending data frames
 inline void Nghttp2Session::SendPendingData() {
   const uint8_t* data;

--- a/src/node_http2_core.cc
+++ b/src/node_http2_core.cc
@@ -85,6 +85,9 @@ int Nghttp2Session::OnFrameReceive(nghttp2_session* session,
     case NGHTTP2_PRIORITY:
       handle->HandlePriorityFrame(frame);
       break;
+    case NGHTTP2_GOAWAY:
+      handle->HandleGoawayFrame(frame);
+      break;
     default:
       break;
   }

--- a/src/node_http2_core.h
+++ b/src/node_http2_core.h
@@ -151,6 +151,10 @@ class Nghttp2Session {
                           int32_t parent,
                           int32_t weight,
                           int8_t exclusive) {}
+  virtual void OnGoAway(int32_t lastStreamID,
+                        uint32_t errorCode,
+                        uint8_t* data,
+                        size_t length) {}
   virtual void OnFrameError(int32_t id,
                             uint8_t type,
                             int error_code) {}
@@ -168,6 +172,7 @@ class Nghttp2Session {
   inline void HandleHeadersFrame(const nghttp2_frame* frame);
   inline void HandlePriorityFrame(const nghttp2_frame* frame);
   inline void HandleDataFrame(const nghttp2_frame* frame);
+  inline void HandleGoawayFrame(const nghttp2_frame* frame);
 
   /* callbacks for nghttp2 */
 #ifdef NODE_DEBUG_HTTP2

--- a/test/parallel/test-http2-goaway-opaquedata.js
+++ b/test/parallel/test-http2-goaway-opaquedata.js
@@ -1,0 +1,33 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http2 = require('http2');
+
+const server = http2.createServer();
+const data = Buffer.from([0x1, 0x2, 0x3, 0x4, 0x5]);
+
+server.on('stream', common.mustCall((stream) => {
+  stream.session.shutdown({
+    errorCode: 1,
+    opaqueData: data
+  });
+  stream.end();
+}));
+
+server.listen(0, () => {
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  client.on('goaway', common.mustCall((code, lastStreamID, buf) => {
+    assert.deepStrictEqual(code, 1);
+    assert.deepStrictEqual(lastStreamID, 0);
+    assert.deepStrictEqual(data, buf);
+    server.close();
+  }));
+  const req = client.request({ ':path': '/' });
+  req.resume();
+  req.on('end', common.mustCall());
+  req.end();
+
+});

--- a/test/parallel/test-http2-serve-file.js
+++ b/test/parallel/test-http2-serve-file.js
@@ -1,0 +1,83 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http2 = require('http2');
+const fs = require('fs');
+const path = require('path');
+const tls = require('tls');
+
+const ajs_data = fs.readFileSync(path.resolve(common.fixturesDir, 'a.js'),
+                                 'utf8');
+
+const {
+  HTTP2_HEADER_PATH,
+  HTTP2_HEADER_STATUS
+} = http2.constants
+
+function loadKey(keyname) {
+  return fs.readFileSync(
+    path.join(common.fixturesDir, 'keys', keyname), 'binary');
+}
+
+const key = loadKey('agent8-key.pem');
+const cert = loadKey('agent8-cert.pem');
+const ca = loadKey('fake-startcom-root-cert.pem');
+
+const server = http2.createSecureServer({key, cert});
+
+server.on('stream', (stream, headers) => {
+  const name = headers[HTTP2_HEADER_PATH].slice(1);
+  const file = path.resolve(common.fixturesDir, name);
+  fs.stat(file, (err, stat) => {
+    if (err != null || stat.isDirectory()) {
+      stream.respond({ [HTTP2_HEADER_STATUS]: 404 });
+      stream.end();
+      return;
+    } else {
+      stream.respond({ [HTTP2_HEADER_STATUS]: 200 });
+      const str = fs.createReadStream(file);
+      str.pipe(stream);
+    }
+  });
+});
+
+server.listen(8000, () => {
+
+  const secureContext = tls.createSecureContext({ca});
+  const client = http2.connect(`https://localhost:${server.address().port}`,
+                               { secureContext });
+
+  let remaining = 2;
+  function maybeClose() {
+    if (--remaining === 0) {
+      client.destroy();
+      server.close();
+    }
+  }
+
+  // Request for a file that does exist, response is 200
+  const req1 = client.request({ [HTTP2_HEADER_PATH]: '/a.js' },
+                              { endStream: true });
+  req1.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[HTTP2_HEADER_STATUS], 200);
+  }));
+  var req1_data = '';
+  req1.setEncoding('utf8');
+  req1.on('data', (chunk) => req1_data += chunk);
+  req1.on('end', common.mustCall(() => {
+    assert.strictEqual(req1_data, ajs_data);
+    maybeClose();
+  }));
+
+  // Request for a file that does not exist, response is 404
+  const req2 = client.request({ [HTTP2_HEADER_PATH]: '/does_not_exist' },
+                              { endStream: true });
+  req2.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[HTTP2_HEADER_STATUS], 404);
+  }));
+  req2.on('data', common.mustNotCall());
+  req2.on('end', common.mustCall(() => maybeClose()));
+
+});

--- a/test/parallel/test-http2-server-shutdown-before-respond.js
+++ b/test/parallel/test-http2-server-shutdown-before-respond.js
@@ -26,8 +26,6 @@ server.on('listening', common.mustCall(() => {
 
   const req = client.request({ ':path': '/' });
 
-  // Shutdown is graceful so this must be called
-  req.on('response', common.mustCall());
   req.resume();
   req.on('end', common.mustCall(() => server.close()));
   req.end();


### PR DESCRIPTION
* Add `goaway` event on sessions
* Graceful session shutdown only works for servers (per nghttp2 requirements)

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2