### PR TITLE
http2: fixed response.end() and cleaned up errors

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -125,13 +125,19 @@ E('ERR_HTTP2_HEADER_REQUIRED',
   (name) => `The ${name} header is required`);
 E('ERR_HTTP2_HEADER_SINGLE_VALUE',
   (name) => `Header field "${name}" must have only a single value`);
+E('ERR_HTTP2_HEADERS_OBJECT', 'Headers must be an object');
 E('ERR_HTTP2_HEADERS_SENT', 'Response has already been initiated.');
 E('ERR_HTTP2_HEADERS_AFTER_RESPOND',
   'Cannot specify additional headers after response initiated');
+E('ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND',
+  'Cannot send informational headers after the HTTP message has been sent');
+E('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED',
+  'Informational status codes cannot be used');
 E('ERR_HTTP2_INVALID_CONNECTION_HEADERS',
   'HTTP/1 Connection specific headers are forbidden');
+E('ERR_HTTP2_INVALID_HEADER_VALUE', 'Value must not be undefined or null');
 E('ERR_HTTP2_INVALID_INFO_STATUS',
-  'Invalid informational status code');
+  (code) => `Invalid informational status code: ${code}`);
 E('ERR_HTTP2_INVALID_PSEUDOHEADER',
   (name) => `"${name}" is an invalid pseudoheader or is used incorrectly`);
 E('ERR_HTTP2_INVALID_SESSION', 'The session has been destroyed');
@@ -142,9 +148,12 @@ E('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
   (max) => `Maximum number of pending settings acknowledgements (${max})`);
 E('ERR_HTTP2_OUT_OF_STREAMS',
   'No stream ID is available because maximum stream ID has been reached');
+E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED', 'Cannot set HTTP/2 pseudo-headers');
 E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams');
 E('ERR_HTTP2_SOCKET_BOUND',
   'The socket is already bound to an Http2Session');
+E('ERR_HTTP2_STATUS_ALREADY_SENT',
+  'Cannot set status after the HTTP message has been sent');
 E('ERR_HTTP2_STATUS_INVALID',
   (code) => `Invalid status code: ${code}`);
 E('ERR_HTTP2_STATUS_101',

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -152,8 +152,6 @@ E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED', 'Cannot set HTTP/2 pseudo-headers');
 E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams');
 E('ERR_HTTP2_SOCKET_BOUND',
   'The socket is already bound to an Http2Session');
-E('ERR_HTTP2_STATUS_ALREADY_SENT',
-  'Cannot set status after the HTTP message has been sent');
 E('ERR_HTTP2_STATUS_INVALID',
   (code) => `Invalid status code: ${code}`);
 E('ERR_HTTP2_STATUS_101',

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -458,7 +458,7 @@ class Http2ServerResponse extends Stream {
     if (chunk !== undefined)
       this.write(chunk, encoding);
 
-    this[kBeginSend]();
+    this[kBeginSend]({endStream: true});
     stream.end();
   }
 
@@ -510,7 +510,7 @@ class Http2ServerResponse extends Stream {
     });
   }
 
-  [kBeginSend]() {
+  [kBeginSend](options) {
     var state = this[kState];
     var stream = this[kStream];
     if (state.headersSent === false) {
@@ -518,7 +518,7 @@ class Http2ServerResponse extends Stream {
       const headers = this[kHeaders] || Object.create(null);
       headers[constants.HTTP2_HEADER_STATUS] = state.statusCode;
       if (stream.destroyed === false)
-        stream.respond(headers);
+        stream.respond(headers, options);
     }
   }
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -275,8 +275,9 @@ class Http2ServerResponse extends Stream {
     stream.on('error', onStreamResponseError);
     stream.on('close', onStreamClosedResponse);
     stream.on('aborted', onAborted.bind(this));
-    stream.on('streamClosed', this[kFinish].bind(this));
-    stream.on('finish', this[kFinish].bind(this));
+    const onfinish = this[kFinish].bind(this);
+    stream.on('streamClosed', onfinish);
+    stream.on('finish', onfinish);
   }
 
   get finished() {
@@ -317,8 +318,6 @@ class Http2ServerResponse extends Stream {
 
   set statusCode(code) {
     var state = this[kState];
-    if (state.headersSent === true)
-      throw new errors.Error('ERR_HTTP2_STATUS_ALREADY_SENT');
     code |= 0;
     if (code >= 100 && code < 200)
       throw new errors.RangeError('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED');
@@ -380,9 +379,6 @@ class Http2ServerResponse extends Stream {
   }
 
   setHeader(name, value) {
-    var state = this[kState];
-    if (state.headersSent === true)
-      throw new errors.Error('ERR_HTTP2_HEADERS_AFTER_RESPOND');
     name = String(name).trim().toLowerCase();
     assertValidHeader(name, value);
     var headers = this[kHeaders];
@@ -392,11 +388,8 @@ class Http2ServerResponse extends Stream {
   }
 
   flushHeaders() {
-    var state = this[kState];
-    if (state.headersSent === true)
-      return;
-    var statusCode = this[kState].statusCode;
-    this.writeHead(statusCode);
+    if (this[kState].headersSent === false)
+      this[kBeginSend]();
   }
 
   writeHead(statusCode, statusMessage, headers) {
@@ -410,9 +403,6 @@ class Http2ServerResponse extends Stream {
     if (headers === undefined && typeof statusMessage === 'object') {
       headers = statusMessage;
     }
-    var state = this[kState];
-    if (state.headersSent === true)
-      return;
     if (headers) {
       var keys = Object.keys(headers);
       var key = '';
@@ -422,9 +412,6 @@ class Http2ServerResponse extends Stream {
       }
     }
     this.statusCode = statusCode;
-    if (this[kStream] === undefined)
-      throw new errors.Error('ERR_HTTP2_STREAM_CLOSED');
-    this[kBeginSend]();
   }
 
   write(chunk, encoding, cb) {
@@ -452,6 +439,7 @@ class Http2ServerResponse extends Stream {
 
     if (typeof chunk === 'function') {
       cb = chunk;
+      chunk = '';
       encoding = 'utf8';
     } else if (typeof encoding === 'function') {
       cb = encoding;
@@ -467,10 +455,11 @@ class Http2ServerResponse extends Stream {
       return;
     }
 
-    if (chunk !== null && chunk !== undefined)
+    if (chunk !== undefined)
       this.write(chunk, encoding);
 
-    stream.end(cb);
+    this[kBeginSend]();
+    stream.end();
   }
 
   destroy(err) {
@@ -528,7 +517,8 @@ class Http2ServerResponse extends Stream {
       state.headersSent = true;
       const headers = this[kHeaders] || Object.create(null);
       headers[constants.HTTP2_HEADER_STATUS] = state.statusCode;
-      stream.respond(headers);
+      if (stream.destroyed === false)
+        stream.respond(headers);
     }
   }
 
@@ -540,6 +530,7 @@ class Http2ServerResponse extends Stream {
     state.closed = true;
     this.end();
     this[kStream] = undefined;
+    this.emit('finish');
   }
 }
 

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -4,6 +4,7 @@ const Stream = require('stream');
 const Readable = Stream.Readable;
 const binding = process.binding('http2');
 const constants = binding.constants;
+const errors = require('internal/errors');
 
 const kFinish = Symbol('finish');
 const kBeginSend = Symbol('begin-send');
@@ -22,9 +23,9 @@ let statusMessageWarned = false;
 
 function assertValidHeader(name, value) {
   if (isPseudoHeader(name))
-    throw new Error('Cannot set HTTP/2 pseudo-headers');
+    throw new errors.Error('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED');
   if (value === undefined || value === null)
-    throw new TypeError('Value must not be undefined or null');
+    throw new errors.TypeError('ERR_HTTP2_INVALID_HEADER_VALUE');
 }
 
 function isPseudoHeader(name) {
@@ -191,7 +192,7 @@ class Http2ServerRequest extends Readable {
     if (stream) {
       stream.resume();
     } else {
-      throw new Error('HTTP/2 Stream has been closed');
+      throw new errors.Error('ERR_HTTP2_STREAM_CLOSED');
     }
   }
 
@@ -317,12 +318,12 @@ class Http2ServerResponse extends Stream {
   set statusCode(code) {
     var state = this[kState];
     if (state.headersSent === true)
-      throw new Error('Cannot set status after the HTTP message has been sent');
+      throw new errors.Error('ERR_HTTP2_STATUS_ALREADY_SENT');
     code |= 0;
     if (code >= 100 && code < 200)
-      throw new RangeError('Informational status codes cannot be used');
+      throw new errors.RangeError('ERR_HTTP2_INFO_STATUS_NOT_ALLOWED');
     if (code < 200 || code > 999)
-      throw new RangeError(`Invalid status code: ${code}`);
+      throw new errors.RangeError('ERR_HTTP2_STATUS_INVALID', code);
     state.statusCode = code;
   }
 
@@ -381,8 +382,7 @@ class Http2ServerResponse extends Stream {
   setHeader(name, value) {
     var state = this[kState];
     if (state.headersSent === true)
-      throw new Error('Cannot set headers after ' +
-        'the HTTP message has been sent');
+      throw new errors.Error('ERR_HTTP2_HEADERS_AFTER_RESPOND');
     name = String(name).trim().toLowerCase();
     assertValidHeader(name, value);
     var headers = this[kHeaders];
@@ -422,6 +422,8 @@ class Http2ServerResponse extends Stream {
       }
     }
     this.statusCode = statusCode;
+    if (this[kStream] === undefined)
+      throw new errors.Error('ERR_HTTP2_STREAM_CLOSED');
     this[kBeginSend]();
   }
 
@@ -434,23 +436,41 @@ class Http2ServerResponse extends Stream {
     }
 
     if (stream === undefined) {
-      var err = new Error('HTTP/2 Stream has been closed');
+      var err = new errors.Error('ERR_HTTP2_STREAM_CLOSED');
       if (cb)
-        cb(err);
+        process.nextTick(cb, err);
       else
-        this.emit('error', err);
+        throw err;
       return;
     }
-    var beginSend = this[kBeginSend];
-    beginSend.call(this);
+    this[kBeginSend]();
     return stream.write(chunk, encoding, cb);
   }
 
   end(chunk, encoding, cb) {
     var stream = this[kStream];
-    if (chunk)
-      this.write(chunk, encoding, cb);
-    stream.end();
+
+    if (typeof chunk === 'function') {
+      cb = chunk;
+      encoding = 'utf8';
+    } else if (typeof encoding === 'function') {
+      cb = encoding;
+      encoding = 'utf8';
+    }
+
+    if (stream === undefined) {
+      var err = new errors.Error('ERR_HTTP2_STREAM_CLOSED');
+      if (cb)
+        process.nextTick(cb, err);
+      else
+        throw err;
+      return;
+    }
+
+    if (chunk !== null && chunk !== undefined)
+      this.write(chunk, encoding);
+
+    stream.end(cb);
   }
 
   destroy(err) {
@@ -475,17 +495,15 @@ class Http2ServerResponse extends Stream {
   sendInfo(code, headers) {
     var state = this[kState];
     if (state.headersSent === true) {
-      throw new Error(
-        'Cannot send informational headers after the HTTP message' +
-        'has been sent');
+      throw new errors.Error('ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND');
     }
     if (headers && typeof headers !== 'object')
-      throw new TypeError('headers must be an object');
+      throw new errors.TypeError('ERR_HTTP2_HEADERS_OBJECT');
     var stream = this[kStream];
     if (stream === undefined) return;
     code |= 0;
     if (code < 100 || code >= 200)
-      throw new RangeError(`Invalid informational status code: ${code}`);
+      throw new errors.RangeError('ERR_HTTP2_INVALID_INFO_STATUS', code);
 
     state.headersSent = true;
     headers[constants.HTTP2_HEADER_STATUS] = code;
@@ -495,7 +513,7 @@ class Http2ServerResponse extends Stream {
   createPushResponse(headers, callback) {
     var stream = this[kStream];
     if (stream === undefined) {
-      throw new Error('HTTP/2 Stream has been closed');
+      throw new errors.Error('ERR_HTTP2_STREAM_CLOSED');
     }
     stream.pushStream(headers, {}, function(stream, headers, options) {
       var response = new Http2ServerResponse(stream);

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1599,7 +1599,7 @@ class ServerHttp2Stream extends Http2Stream {
         throw new errors.Error('ERR_HTTP2_STATUS_101');
       if (statusCode < 100 || statusCode >= 200) {
         throw new errors.RangeError('ERR_HTTP2_INVALID_INFO_STATUS',
-                                    statusCode);
+                                    headers[HTTP2_HEADER_STATUS]);
       }
     }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1077,6 +1077,8 @@ function onHandleFinish() {
   if (this[kID] === undefined) {
     this.once('ready', onHandleFinish.bind(this));
   } else {
+    if (this[kState].headersSent === false)
+      this.rstWithNoError();
     const handle = session[kHandle];
     if (handle !== undefined) {
       // Shutdown on the next tick of the event loop just in case there is
@@ -1565,7 +1567,7 @@ class ServerHttp2Stream extends Http2Stream {
       default:
         if (ret < 0) {
           err = new NghttpError(ret);
-          process.nextTick(this.emit('error', err));
+          process.nextTick(() => this.emit('error', err));
           return;
         }
         state.headersSent = true;
@@ -1595,8 +1597,10 @@ class ServerHttp2Stream extends Http2Stream {
       const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
       if (statusCode === HTTP_STATUS_SWITCHING_PROTOCOLS)
         throw new errors.Error('ERR_HTTP2_STATUS_101');
-      if (statusCode < 100 || statusCode >= 200)
-        throw new errors.RangeError('ERR_HTTP2_INVALID_INFO_STATUS');
+      if (statusCode < 100 || statusCode >= 200) {
+        throw new errors.RangeError('ERR_HTTP2_INVALID_INFO_STATUS',
+                                    statusCode);
+      }
     }
 
     _unrefActive(this);

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1077,8 +1077,6 @@ function onHandleFinish() {
   if (this[kID] === undefined) {
     this.once('ready', onHandleFinish.bind(this));
   } else {
-    if (this[kState].headersSent === false)
-      this.rstWithNoError();
     const handle = session[kHandle];
     if (handle !== undefined) {
       // Shutdown on the next tick of the event loop just in case there is

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -45,7 +45,7 @@ server.listen(0, common.mustCall(function() {
     assert.strictEqual(request.url, '/two');
     assert.strictEqual(request.path, '/two');
 
-    response.stream.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(function() {
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-compat-serverrequest-headers.js
+++ b/test/parallel/test-http2-compat-serverrequest-headers.js
@@ -48,7 +48,7 @@ server.listen(0, common.mustCall(function() {
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));
-    response.end(' ');
+    response.end();
   }));
 
   const url = `http://localhost:${port}`;

--- a/test/parallel/test-http2-compat-serverrequest.js
+++ b/test/parallel/test-http2-compat-serverrequest.js
@@ -28,7 +28,7 @@ server.listen(0, common.mustCall(function() {
     assert.ok(request.connection instanceof net.Socket);
     assert.strictEqual(request.socket, request.connection);
 
-    response.stream.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(function() {
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-compat-serverrequest.js
+++ b/test/parallel/test-http2-compat-serverrequest.js
@@ -31,7 +31,7 @@ server.listen(0, common.mustCall(function() {
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));
-    response.end(' ');
+    response.end();
   }));
 
   const url = `http://localhost:${port}`;

--- a/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
+++ b/test/parallel/test-http2-compat-serverresponse-createpushresponse.js
@@ -14,7 +14,7 @@ server.listen(0, common.mustCall(function() {
     assert.ok(response.stream.id % 2 === 1);
 
     response.write('This is a client-initiated response');
-    response.stream.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(function() {
       server.close();
     }));
 

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -1,7 +1,7 @@
 // Flags: --expose-http2
 'use strict';
 
-const { mustCall } = require('../common');
+const { mustCall, mustNotCall } = require('../common');
 const { createServer, connect } = require('http2');
 
 // Http2ServerResponse.end
@@ -26,6 +26,7 @@ const { createServer, connect } = require('http2');
         ':authority': `localhost:${port}`
       };
       const request = client.request(headers);
+      request.on('data', mustNotCall())
       request.on('end', mustCall(() => {
         client.destroy();
       }));

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -1,0 +1,42 @@
+// Flags: --expose-http2
+'use strict';
+
+const { mustCall, expectsError } = require('../common');
+const { createServer, connect } = require('http2');
+
+// Http2ServerResponse should throw when writing if the stream is closed
+
+const server = createServer();
+server.listen(0, mustCall(() => {
+  const port = server.address().port;
+  server.once('request', mustCall((request, response) => {
+    response.stream.on('finish', mustCall(() => {
+      try {
+        response.writeHead(200);
+        throw new Error();
+      } catch (error) {
+        const code = 'ERR_HTTP2_STREAM_CLOSED';
+        const message = 'The stream is already closed';
+        expectsError({code, message})(error);
+      }
+      server.close();
+    }));
+    response.end();
+  }));
+
+  const url = `http://localhost:${port}`;
+  const client = connect(url, mustCall(() => {
+    const headers = {
+      ':path': '/',
+      ':method': 'GET',
+      ':scheme': 'http',
+      ':authority': `localhost:${port}`
+    };
+    const request = client.request(headers);
+    request.on('end', mustCall(() => {
+      client.destroy();
+    }));
+    request.end();
+    request.resume();
+  }));
+}));

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -1,7 +1,8 @@
 // Flags: --expose-http2
 'use strict';
 
-const { mustCall, expectsError } = require('../common');
+const { throws } = require('assert');
+const { mustCall } = require('../common');
 const { createServer, connect } = require('http2');
 
 // Http2ServerResponse should throw when writing if the stream is closed
@@ -11,14 +12,10 @@ server.listen(0, mustCall(() => {
   const port = server.address().port;
   server.once('request', mustCall((request, response) => {
     response.stream.on('finish', mustCall(() => {
-      try {
-        response.writeHead(200);
-        throw new Error();
-      } catch (error) {
-        const code = 'ERR_HTTP2_STREAM_CLOSED';
-        const message = 'The stream is already closed';
-        expectsError({code, message})(error);
-      }
+      throws(
+        () => { response.writeHead(200); },
+        /The stream is already closed/
+      );
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-compat-serverresponse-end.js
+++ b/test/parallel/test-http2-compat-serverresponse-end.js
@@ -1,39 +1,36 @@
 // Flags: --expose-http2
 'use strict';
 
-const { throws } = require('assert');
 const { mustCall } = require('../common');
 const { createServer, connect } = require('http2');
 
-// Http2ServerResponse should throw when writing if the stream is closed
+// Http2ServerResponse.end
 
-const server = createServer();
-server.listen(0, mustCall(() => {
-  const port = server.address().port;
-  server.once('request', mustCall((request, response) => {
-    response.stream.on('finish', mustCall(() => {
-      throws(
-        () => { response.writeHead(200); },
-        /The stream is already closed/
-      );
-      server.close();
+{
+  const server = createServer();
+  server.listen(0, mustCall(() => {
+    const port = server.address().port;
+    server.once('request', mustCall((request, response) => {
+      response.on('finish', mustCall(() => {
+        server.close();
+      }));
+      response.end();
     }));
-    response.end();
-  }));
 
-  const url = `http://localhost:${port}`;
-  const client = connect(url, mustCall(() => {
-    const headers = {
-      ':path': '/',
-      ':method': 'GET',
-      ':scheme': 'http',
-      ':authority': `localhost:${port}`
-    };
-    const request = client.request(headers);
-    request.on('end', mustCall(() => {
-      client.destroy();
+    const url = `http://localhost:${port}`;
+    const client = connect(url, mustCall(() => {
+      const headers = {
+        ':path': '/',
+        ':method': 'GET',
+        ':scheme': 'http',
+        ':authority': `localhost:${port}`
+      };
+      const request = client.request(headers);
+      request.on('end', mustCall(() => {
+        client.destroy();
+      }));
+      request.end();
+      request.resume();
     }));
-    request.end();
-    request.resume();
   }));
-}));
+}

--- a/test/parallel/test-http2-compat-serverresponse-finished.js
+++ b/test/parallel/test-http2-compat-serverresponse-finished.js
@@ -15,7 +15,7 @@ server.listen(0, common.mustCall(function() {
       server.close();
     }));
     assert.strictEqual(response.finished, false);
-    response.end(' ');
+    response.end();
     assert.strictEqual(response.finished, true);
   }));
 

--- a/test/parallel/test-http2-compat-serverresponse-finished.js
+++ b/test/parallel/test-http2-compat-serverresponse-finished.js
@@ -11,7 +11,7 @@ const server = h2.createServer();
 server.listen(0, common.mustCall(function() {
   const port = server.address().port;
   server.once('request', common.mustCall(function(request, response) {
-    response.stream.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(function() {
       server.close();
     }));
     assert.strictEqual(response.finished, false);

--- a/test/parallel/test-http2-compat-serverresponse-flushheaders.js
+++ b/test/parallel/test-http2-compat-serverresponse-flushheaders.js
@@ -18,7 +18,7 @@ server.listen(0, common.mustCall(function() {
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));
-    response.end(' ');
+    response.end();
   }));
 
   const url = `http://localhost:${port}`;

--- a/test/parallel/test-http2-compat-serverresponse-flushheaders.js
+++ b/test/parallel/test-http2-compat-serverresponse-flushheaders.js
@@ -13,9 +13,9 @@ server.listen(0, common.mustCall(function() {
   server.once('request', common.mustCall(function(request, response) {
     response.flushHeaders();
     response.flushHeaders(); // Idempotent
-    response.writeHead(200, {'foo-bar': 'abc123'}); // Ignored
+    response.writeHead(400, {'foo-bar': 'abc123'}); // Ignored
 
-    response.stream.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(function() {
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -59,7 +59,7 @@ server.listen(0, common.mustCall(function() {
     response.getHeaders()[fake] = fake;
     assert.strictEqual(response.hasHeader(fake), false);
 
-    response.stream.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(function() {
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -62,7 +62,7 @@ server.listen(0, common.mustCall(function() {
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));
-    response.end(' ');
+    response.end();
   }));
 
   const url = `http://localhost:${port}`;

--- a/test/parallel/test-http2-compat-serverresponse-statuscode.js
+++ b/test/parallel/test-http2-compat-serverresponse-statuscode.js
@@ -48,7 +48,7 @@ server.listen(0, common.mustCall(function() {
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));
-    response.end(' ');
+    response.end();
   }));
 
   const url = `http://localhost:${port}`;

--- a/test/parallel/test-http2-compat-serverresponse-statuscode.js
+++ b/test/parallel/test-http2-compat-serverresponse-statuscode.js
@@ -45,7 +45,7 @@ server.listen(0, common.mustCall(function() {
       response.statusCode = fakeStatusCodes.tooHigh;
     }, RangeError);
 
-    response.stream.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(function() {
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -24,7 +24,7 @@ server.listen(0, common.mustCall(function() {
     const headers = {'foo-bar': 'abc123'};
     response.writeHead(statusCode, statusMessage, headers);
 
-    response.stream.on('finish', common.mustCall(function() {
+    response.on('finish', common.mustCall(function() {
       server.close();
     }));
     response.end();

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage.js
@@ -27,7 +27,7 @@ server.listen(0, common.mustCall(function() {
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));
-    response.end(' ');
+    response.end();
   }));
 
   const url = `http://localhost:${port}`;

--- a/test/parallel/test-http2-compat-serverresponse-write-no-cb.js
+++ b/test/parallel/test-http2-compat-serverresponse-write-no-cb.js
@@ -1,16 +1,9 @@
 // Flags: --expose-http2
 'use strict';
 
-const {
-  mustCall,
-  mustNotCall,
-  expectsError
-} = require('../common');
-
-const {
-  createServer,
-  connect
-} = require('http2');
+const { throws } = require('assert');
+const { mustCall, mustNotCall, expectsError } = require('../common');
+const { createServer, connect } = require('http2');
 
 // Http2ServerResponse.write does not imply there is a callback
 
@@ -40,12 +33,10 @@ const expectedError = expectsError({
       client.destroy();
       response.stream.session.on('close', mustCall(() => {
         response.on('error', mustNotCall());
-        try {
-          response.write('muahaha');
-          throw new Error();
-        } catch (error) {
-          expectedError(error);
-        }
+        throws(
+          () => { response.write('muahaha'); },
+          /The stream is already closed/
+        );
         server.close();
       }));
     }));

--- a/test/parallel/test-http2-compat-serverresponse-writehead.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead.js
@@ -21,7 +21,7 @@ server.listen(0, common.mustCall(function() {
     response.stream.on('finish', common.mustCall(function() {
       server.close();
     }));
-    response.end(' ');
+    response.end();
   }));
 
   const url = `http://localhost:${port}`;

--- a/test/parallel/test-http2-info-headers.js
+++ b/test/parallel/test-http2-info-headers.js
@@ -21,7 +21,7 @@ function onStream(stream, headers, flags) {
                 common.expectsError({
                   code: 'ERR_HTTP2_INVALID_INFO_STATUS',
                   type: RangeError,
-                  message: /^Invalid informational status code$/
+                  message: /^Invalid informational status code: 201$/
                 }));
 
   assert.throws(() => stream.additionalHeaders({ ':status': 101 }),

--- a/test/parallel/test-http2-serve-file.js
+++ b/test/parallel/test-http2-serve-file.js
@@ -14,7 +14,7 @@ const ajs_data = fs.readFileSync(path.resolve(common.fixturesDir, 'a.js'),
 const {
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_STATUS
-} = http2.constants
+} = http2.constants;
 
 function loadKey(keyname) {
   return fs.readFileSync(
@@ -34,7 +34,6 @@ server.on('stream', (stream, headers) => {
     if (err != null || stat.isDirectory()) {
       stream.respond({ [HTTP2_HEADER_STATUS]: 404 });
       stream.end();
-      return;
     } else {
       stream.respond({ [HTTP2_HEADER_STATUS]: 200 });
       const str = fs.createReadStream(file);
@@ -63,7 +62,7 @@ server.listen(8000, () => {
   req1.on('response', common.mustCall((headers) => {
     assert.strictEqual(headers[HTTP2_HEADER_STATUS], 200);
   }));
-  var req1_data = '';
+  let req1_data = '';
   req1.setEncoding('utf8');
   req1.on('data', (chunk) => req1_data += chunk);
   req1.on('end', common.mustCall(() => {


### PR DESCRIPTION
- Fixed `response.end()` so that it works when not sending any headers nor data frames. It just resets the stream without any error. Added a test for this. Also handles the optional encoding/chunk better and now passes the callback to `end` (aka `finish` event) instead of `send`.
- Moved all the error messages into the common errors file. Some are tweaked, hope that's not a problem since we're still pre-release.
- Added a test for sending headers after the stream closes. Throws a proper error message instead of just saying stream is undefined. (This was showing up in my app. Scenario: hammering browser refresh leads to a race condition where connection can be closed before a response has been served.)
- Changed `response.write()` to throw error when no callback is supplied, instead of emitting `error` event. This feels more in line with HTTP/1 implementation.
- Fixed linting in unrelated tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->

http2