### PR TITLE
http2: add http2stream.respondWithFile()

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -59,6 +59,9 @@ req.end();
 ```
 
 ### Class: Http2Session
+<!-- YAML
+added: REPLACEME
+-->
 
 * Extends: {EventEmitter}
 
@@ -90,10 +93,16 @@ Once a `Socket` has been bound to an `Http2Session`, user code should rely
 solely on the API of the `Http2Session`.
 
 #### Event: 'close'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'close'` event is emitted once the `Http2Session` has been terminated.
 
 #### Event: 'connect'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'connect'` event is emitted once the `Http2Session` has been successfully
 connected to the remote peer and communication may begin.
@@ -101,17 +110,22 @@ connected to the remote peer and communication may begin.
 *Note*: User code will typically not listen for this event directly.
 
 #### Event: 'error'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'error'` event is emitted when an error occurs during the processing of
 an `Http2Session`.
 
 #### Event: 'frameError'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'frameError'` event is emitted when an error occurs while attempting to
 send a frame on the session. If the frame that could not be sent is associated
 with a specific `Http2Stream`, an attempt to emit `'frameError'` event on the
-`Http2Stream` is made. If the `Http2Stream` `'frameError'` event is not handled,
-the `'frameError'` is emitted on the `Http2Session`.
+`Http2Stream` is made.
 
 When invoked, the handler function will receive three arguments:
 
@@ -126,6 +140,9 @@ event is not associated with a stream, the `Http2Session` will be shutdown
 immediately following the `'frameError'` event.
 
 #### Event: 'goaway'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'goaway'` event is emitted when a GOAWAY frame is received. When invoked,
 the handler function will receive three arguments:
@@ -140,6 +157,9 @@ the handler function will receive three arguments:
 `'goaway'` event is emitted.
 
 #### Event: 'localSettings'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'localSettings'` event is emitted when an acknowledgement SETTINGS frame
 has been received. When invoked, the handler function will receive a copy of
@@ -158,6 +178,9 @@ session.on('localSettings', (settings) => {
 ```
 
 #### Event: 'remoteSettings'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'remoteSettings'` event is emitted when a new SETTINGS frame is received
 from the connected peer. When invoked, the handle function will receive a copy
@@ -170,6 +193,9 @@ session.on('remoteSettings', (settings) => {
 ```
 
 #### Event: 'stream'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'stream'` event is emitted when a new `Http2Stream` is created. When
 invoked, the handler function will receive a reference to the `Http2Stream`
@@ -220,6 +246,9 @@ server.listen(80);
 ```
 
 #### Event: 'socketError'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'socketError'` event is emitted when an `'error'` is emitted on the
 `Socket` instance bound to the `Http2Session`. If this event is not handled,
@@ -230,6 +259,9 @@ Likewise, when an `'error'` event is emitted on the `Http2Session`, a
 not handled, the `'error'` event will be re-emitted on the `Http2Session`.
 
 #### Event: 'timeout'
+<!-- YAML
+added: REPLACEME
+-->
 
 After the `http2session.setTimeout()` method is used to set the timeout period
 for this `Http2Session`, the `'timeout'` event is emitted if there is no
@@ -241,6 +273,9 @@ session.on('timeout', () => { /** .. **/ });
 ```
 
 #### http2session.destroy()
+<!-- YAML
+added: REPLACEME
+-->
 
 * Returns: {undefined}
 
@@ -248,6 +283,9 @@ Immediately terminates the `Http2Session` and the associated `net.Socket` or
 `tls.TLSSocket`.
 
 #### http2session.destroyed
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {boolean}
 
@@ -255,6 +293,9 @@ Will be `true` if this `Http2Session` instance has been destroyed and must no
 longer be used, otherwise `false`.
 
 #### http2session.localSettings
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {[Settings Object][]}
 
@@ -262,6 +303,9 @@ A prototype-less object describing the current local settings of this
 `Http2Session`. The local settings are local to *this* `Http2Session` instance.
 
 #### http2session.pendingSettingsAck
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {boolean}
 
@@ -271,6 +315,9 @@ acknowledgement for a sent SETTINGS frame. Will be `true` after calling the
 frames have been acknowledged.
 
 #### http2session.remoteSettings
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {[Settings Object][]}
 
@@ -278,6 +325,9 @@ A prototype-less object describing the current remote settings of this
 `Http2Session`. The remote settings are set by the *connected* HTTP/2 peer.
 
 #### http2session.request(headers[, options])
+<!-- YAML
+added: REPLACEME
+-->
 
 * `headers` {[Headers Object][]}
 * `options` {Object}
@@ -319,6 +369,9 @@ req.on('response', (headers) => {
 ```
 
 #### http2session.rstStream(stream, code)
+<!-- YAML
+added: REPLACEME
+-->
 
 * stream {Http2Stream}
 * code {number} Unsigned 32-bit integer identifying the error code. Defaults to
@@ -329,6 +382,9 @@ Sends an `RST_STREAM` frame to the connected HTTP/2 peer, causing the given
 `Http2Stream` to be closed on both sides using [error code][] `code`.
 
 #### http2session.setTimeout(msecs, callback)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `msecs` {number}
 * `callback` {Function}
@@ -339,6 +395,9 @@ the `Http2Session` after `msecs` milliseconds. The given `callback` is
 registered as a listener on the `'timeout'` event.
 
 #### http2session.shutdown(options[, callback])
+<!-- YAML
+added: REPLACEME
+-->
 
 * `options` {Object}
   * `graceful` {boolean} `true` to attempt a polite shutdown of the
@@ -377,6 +436,9 @@ session.shutdown({
 ```
 
 #### http2session.socket
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {net.Socket|tls.TLSSocket}
 
@@ -388,6 +450,9 @@ A reference to the [`net.Socket`][] or [`tls.TLSSocket`][] to which this
 details.
 
 #### http2session.state
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {Object}
   * `effectiveLocalWindowSize` {number}
@@ -403,6 +468,9 @@ details.
 An object describing the current status of this `Http2Session`.
 
 #### http2session.priority(stream, options)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `stream` {Http2Stream}
 * `options` {Object}
@@ -422,6 +490,9 @@ An object describing the current status of this `Http2Session`.
 Updates the priority for the given `Http2Stream` instance.
 
 #### http2session.settings(settings)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `settings` {[Settings Object][]}
 * Returns {undefined}
@@ -439,6 +510,9 @@ is possible to send multiple SETTINGS frames while acknowledgement is still
 pending.
 
 #### http2session.type
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {number}
 
@@ -448,6 +522,9 @@ server, and `http2.constants.NGHTTP2_SESSION_CLIENT` if the instance is a
 client.
 
 ### Class: Http2Stream
+<!-- YAML
+added: REPLACEME
+-->
 
 * Extends: {Duplex}
 
@@ -518,6 +595,9 @@ property will be `true` and the `http2stream.rstCode` property will specify the
 destroyed.
 
 #### Event: 'aborted'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'aborted'` event is emitted whenever a `Http2Stream` instance is
 abnormally aborted in mid-communication.
@@ -526,11 +606,17 @@ abnormally aborted in mid-communication.
 writable side has not been ended.
 
 #### Event: 'error'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'error'` event is emitted when an error occurs during the processing of
 an `Http2Stream`.
 
 #### Event: 'fetchTrailers'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'fetchTrailers'` event is emitted by the `Http2Stream` immediately after
 queuing the last chunk of payload data to be sent. The listener callback is
@@ -549,28 +635,41 @@ will be emitted if the `'fetchTrailers'` event handler attempts to set such
 header fields.
 
 #### Event: 'frameError'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'frameError'` event is emitted when an error occurs while attempting to
-send a frame on the stream. When invoked, the handler function will receive
-an integer argument identifying the frame type, and an integer argument
-identifying the error code. The `Http2Stream` instance will be destroyed
-immediately after the `'frameError'` event is emitted.
-
-If the `'frameError'` event is not handled on the `Http2Stream` object, a
-`'frameError'` event will be emitted on the owning `Http2Session` object.
+send a frame. When invoked, the handler function will receive an integer
+argument identifying the frame type, and an integer argument identifying the
+error code. The `Http2Stream` instance will be destroyed immediately after the
+`'frameError'` event is emitted.
 
 #### Event: 'streamClosed'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'streamClosed'` event is emitted when the `Http2Stream` is destroyed. Once
 this event is emitted, the `Http2Stream` instance is no longer usable.
 
+The listener callback is passed a single argument specifying the HTTP/2 error
+code specified when closing the stream. If the code is any value other than
+`NGHTTP2_NO_ERROR` (`0`), an `'error'` event will also be emitted.
+
 #### Event: 'timeout'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'timeout'` event is emitted after no activity is received for this
 `'Http2Stream'` within the number of millseconds set using
 `http2stream.setTimeout()`.
 
 #### Event: 'trailers'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'trailers'` event is emitted when a block of headers associated with
 trailing header fields is received. The listener callback is passed the
@@ -583,6 +682,9 @@ stream.on('trailers', (headers, flags) => {
 ```
 
 #### http2stream.aborted
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {boolean}
 
@@ -590,6 +692,9 @@ Set to `true` if the `Http2Stream` instance was aborted abnormally. When set,
 the `'aborted'` event will have been emitted.
 
 #### http2stream.destroyed
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {boolean}
 
@@ -597,6 +702,9 @@ Set to `true` if the `Http2Stream` instance has been destroyed and is no longer
 usable.
 
 #### http2stream.priority(options)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `options` {Object}
   * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
@@ -615,6 +723,9 @@ usable.
 Updates the priority for this `Http2Stream` instance.
 
 #### http2stream.rstCode
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {number}
 
@@ -624,6 +735,9 @@ calling `http2stream.rstStream()`, or `http2stream.destroy()`. Will be
 `undefined` if the `Http2Stream` has not been closed.
 
 #### http2stream.rstStream(code)
+<!-- YAML
+added: REPLACEME
+-->
 
 * code {number} Unsigned 32-bit integer identifying the error code. Defaults to
   `http2.constant.NGHTTP2_NO_ERROR` (`0x00`)
@@ -633,36 +747,54 @@ Sends an `RST_STREAM` frame to the connected HTTP/2 peer, causing this
 `Http2Stream` to be closed on both sides using [error code][] `code`.
 
 #### http2stream.rstWithNoError()
+<!-- YAML
+added: REPLACEME
+-->
 
 * Returns: {undefined}
 
 Shortcut for `http2stream.rstStream()` using error code `0x00` (No Error).
 
 #### http2stream.rstWithProtocolError() {
+<!-- YAML
+added: REPLACEME
+-->
 
 * Returns: {undefined}
 
 Shortcut for `http2stream.rstStream()` using error code `0x01` (Protocol Error).
 
 #### http2stream.rstWithCancel() {
+<!-- YAML
+added: REPLACEME
+-->
 
 * Returns: {undefined}
 
 Shortcut for `http2stream.rstStream()` using error code `0x08` (Cancel).
 
 #### http2stream.rstWithRefuse() {
+<!-- YAML
+added: REPLACEME
+-->
 
 * Returns: {undefined}
 
 Shortcut for `http2stream.rstStream()` using error code `0x07` (Refused Stream).
 
 #### http2stream.rstWithInternalError() {
+<!-- YAML
+added: REPLACEME
+-->
 
 * Returns: {undefined}
 
 Shortcut for `http2stream.rstStream()` using error code `0x02` (Internal Error).
 
 #### http2stream.session
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {Http2Sesssion}
 
@@ -670,6 +802,9 @@ A reference to the `Http2Session` instance that owns this `Http2Stream`. The
 value will be `undefined` after the `Http2Stream` instance is destroyed.
 
 #### http2stream.setTimeout(msecs, callback)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `msecs` {number}
 * `callback` {Function}
@@ -686,6 +821,9 @@ req.setTimeout(5000, () => req.rstStreamWithCancel());
 ```
 
 #### http2stream.state
+<!-- YAML
+added: REPLACEME
+-->
 
 * Value: {Object}
   * `localWindowSize` {number}
@@ -698,6 +836,9 @@ req.setTimeout(5000, () => req.rstStreamWithCancel());
 A current state of this `Http2Stream`.
 
 ### Class: ClientHttp2Stream
+<!-- YAML
+added: REPLACEME
+-->
 
 * Extends {Http2Stream}
 
@@ -707,6 +848,9 @@ provide events such as `'response'` and `'push'` that are only relevant on
 the client.
 
 #### Event: 'headers'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'headers'` event is emitted when an additional block of headers is received
 for a stream, such as when a block of `1xx` informational headers are received.
@@ -720,6 +864,9 @@ stream.on('headers', (headers, flags) => {
 ```
 
 #### Event: 'push'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'push'` event is emitted when response headers for a Server Push stream
 are received. The listener callback is passed the [Headers Object][] and flags
@@ -732,6 +879,9 @@ stream.on('push', (headers, flags) => {
 ```
 
 #### Event: 'response'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'response'` event is emitted when a response `HEADERS` frame has been
 received for this stream from the connected HTTP/2 server. The listener is
@@ -750,6 +900,9 @@ req.on('response', (headers, flags) => {
 ```
 
 ### Class: ServerHttp2Stream
+<!-- YAML
+added: REPLACEME
+-->
 
 * Extends: {Http2Stream}
 
@@ -759,6 +912,9 @@ provide additional methods such as `http2stream.pushStream()` and
 `http2stream.respond()` that are only relevant on the server.
 
 #### http2stream.additionalHeaders(headers)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `headers` {[Headers Object][]}
 * Returns: {undefined}
@@ -766,6 +922,9 @@ provide additional methods such as `http2stream.pushStream()` and
 Sends an additional informational `HEADERS` frame to the connected HTTP/2 peer.
 
 #### http2stream.pushStream(headers[, options], callback)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `headers` {[Headers Object][]}
 * `options` {Object}
@@ -799,9 +958,14 @@ server.on('stream', (stream) => {
 ```
 
 #### http2stream.respond([headers[, options]])
+<!-- YAML
+added: REPLACEME
+-->
 
 * `headers` {[Headers Object][]}
 * `options` {Object}
+  * `endStream` {boolean} Set to `true` to indicate that the response will not
+    include payload data.
 * Returns: {undefined}
 
 ```js
@@ -813,23 +977,133 @@ server.on('stream', (stream) => {
 });
 ```
 
+#### http2stream.respondWithFD(fd[, headers])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `fd` {number} A readable file descriptor
+* `headers` {[Headers Object][]}
+
+Initiates a response whose data is read from the given file descriptor. No
+validation is performed on the given file descriptor. If an error occurs while
+attempting to read data using the file descriptor, the `Http2Stream` will be
+closed using an `RST_STREAM` frame using the standard `INTERNAL_ERROR` code.
+
+When used, the `Http2Stream` object's Duplex interface will be closed
+automatically. HTTP trailer fields cannot be sent. The `'fetchTrailers'` event
+will *not* be emitted.
+
+```js
+const http2 = require('http2');
+const fs = require('fs');
+
+const fd = fs.openSync('/some/file', 'r');
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  const stat = fs.fstatSync(fd);
+  const headers = {
+    'content-length': stat.size,
+    'last-modified': stat.mtime.toUTCString(),
+    'content-type': 'text/plain'
+  };
+  stream.respondWithFD(fd, headers);
+});
+server.on('close', () => fs.closeSync(fd));
+```
+
+#### http2stream.respondWithFile(path[, headers[, options]])
+<!-- YAML
+added: REPLACEME
+-->
+
+* `path` {string|Buffer|URL}
+* `headers` {[Headers Object][]}
+* `options` {Object}
+  * `statCheck` {Function}
+
+Sends a regular file as the response. The `path` must specify a regular file
+or an `'error'` event will be emitted on the `Http2Stream` object.
+
+When used, the `Http2Stream` object's Duplex interface will be closed
+automatically. HTTP trailer fields cannot be sent. The `'fetchTrailers'` event
+will *not* be emitted.
+
+The optional `options.statCheck` function may be specified to give user code
+an opportunity to set additional content headers based on the `fs.Stat` details
+of the given file:
+
+If an error occurs while attempting to read the file data, the `Http2Stream`
+will be closed using an `RST_STREAM` frame using the standard `INTERNAL_ERROR`
+code.
+
+Example using a file path:
+
+```js
+const http2 = require('http2');
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  function statCheck(stat, headers) {
+    headers['last-modified'] = stat.mtime.toUTCString();
+  }
+  stream.respondWithFile('/some/file',
+                         { 'content-type': 'text/plain' },
+                         { statCheck });
+});
+```
+
+The `options.statCheck` function may also be used to cancel the send operation
+by returning `false`. For instance, a conditional request may check the stat
+results to determine if the file has been modified to return an appropriate
+`304` response:
+
+```js
+const http2 = require('http2');
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  function statCheck(stat, headers) {
+    // Check the stat here...
+    stream.respond({ ':status': 304 });
+    return false; // Cancel the send operation
+  }
+  stream.respondWithFile('/some/file',
+                         { 'content-type': 'text/plain' },
+                         { statCheck });
+});
+```
+
+The `content-length` header field will be automatically set.
+
 ### Class: Http2Server
+<!-- YAML
+added: REPLACEME
+-->
 
 * Extends: {net.Server}
 
 #### Event: 'sessionError'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'sessionError'` event is emitted when an `'error'` event is emitted by
 an `Http2Session` object. If no listener is registered for this event, an
 `'error'` event is emitted.
 
 #### Event: 'socketError'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'socketError'` event is emitted when an `'error'` event is emitted by
 a `Socket` associated with the server. If no listener is registered for this
 event, an `'error'` event is emitted.
 
 #### Event: 'stream'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'stream'` event is emitted when a `'stream'` event has been emitted by
 an `Http2Session` associated with the server.
@@ -858,27 +1132,42 @@ server.on('stream', (stream, headers, flags) => {
 ```
 
 #### Event: 'timeout'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
 
 ### Class: Http2SecureServer
+<!-- YAML
+added: REPLACEME
+-->
 
 * Extends: {tls.Server}
 
 #### Event: 'sessionError'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'sessionError'` event is emitted when an `'error'` event is emitted by
 an `Http2Session` object. If no listener is registered for this event, an
 `'error'` event is emitted on the `Http2Session` instance instead.
 
 #### Event: 'socketError'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'socketError'` event is emitted when an `'error'` event is emitted by
 a `Socket` associated with the server. If no listener is registered for this
 event, an `'error'` event is emitted on the `Socket` instance instead.
 
 #### Event: 'unknownProtocol'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'unknownProtocol'` event is emitted when a connecting client fails to
 negotiate an allowed protocol (i.e. HTTP/2 or HTTP/1.1). The event handler
@@ -886,6 +1175,9 @@ receives the socket for handling. If no listener is registered for this event,
 the connection is terminated. See the
 
 #### Event: 'stream'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'stream'` event is emitted when a `'stream'` event has been emitted by
 an `Http2Session` associated with the server.
@@ -916,11 +1208,17 @@ server.on('stream', (stream, headers, flags) => {
 ```
 
 #### Event: 'timeout'
+<!-- YAML
+added: REPLACEME
+-->
 
 The `'timeout'` event is emitted when there is no activity on the Server for
 a given number of milliseconds set using `http2server.setTimeout()`.
 
 ### http2.getDefaultSettings()
+<!-- YAML
+added: REPLACEME
+-->
 
 * Returns: {[Settings Object][]}
 
@@ -929,6 +1227,9 @@ instance. This method returns a new object instance every time it is called
 so instances returned may be safely modified for use.
 
 ### http2.getPackedSettings(settings)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `settings` {[Settings Object][]}
 * Returns: {Buffer}
@@ -947,6 +1248,9 @@ console.log(packed.toString('base64'));
 ```
 
 ### http2.createServer(options[, onRequestHandler])
+<!-- YAML
+added: REPLACEME
+-->
 
 * `options` {Object}
   * `maxDeflateDynamicTableSize` {number} Sets the maximum dynamic table size
@@ -999,6 +1303,9 @@ server.listen(80);
 ```
 
 ### http2.createSecureServer(options[, onRequestHandler])
+<!-- YAML
+added: REPLACEME
+-->
 
 * `options` {Object}
   * `allowHTTP1` {boolean} Incoming client connections that do not support
@@ -1061,6 +1368,9 @@ server.listen(80);
 ```
 
 ### http2.connect(authority, options, listener)
+<!-- YAML
+added: REPLACEME
+-->
 
 * `authority` {string|URL}
 * `options` {Object}
@@ -1109,6 +1419,9 @@ client.destroy();
 ```
 
 ### http2.constants
+<!-- YAML
+added: REPLACEME
+-->
 
 #### Error Codes for RST_STREAM and GOAWAY
 <a id="error_codes"></a>

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -127,6 +127,14 @@ E('ERR_HTTP2_CONNECT_PATH',
   'The :path header is forbidden for CONNECT requests');
 E('ERR_HTTP2_CONNECT_SCHEME',
   'The :scheme header is forbidden for CONNECT requests');
+E('ERR_HTTP2_FRAME_ERROR',
+  (type, code, id) => {
+    let msg = `Error sending frame type ${type}`;
+    if (id !== undefined)
+      msg += ` for stream ${id}`;
+    msg += ` with code ${code}`;
+    return msg;
+  });
 E('ERR_HTTP2_HEADER_REQUIRED',
   (name) => `The ${name} header is required`);
 E('ERR_HTTP2_HEADER_SINGLE_VALUE',
@@ -152,10 +160,13 @@ E('ERR_HTTP2_INVALID_SETTING_VALUE',
   (name, value) => `Invalid value for setting "${name}": ${value}`);
 E('ERR_HTTP2_MAX_PENDING_SETTINGS_ACK',
   (max) => `Maximum number of pending settings acknowledgements (${max})`);
+E('ERR_HTTP2_PAYLOAD_FORBIDDEN',
+  (code) => `Responses with ${code} status must not have a payload`);
 E('ERR_HTTP2_OUT_OF_STREAMS',
   'No stream ID is available because maximum stream ID has been reached');
 E('ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED', 'Cannot set HTTP/2 pseudo-headers');
 E('ERR_HTTP2_PUSH_DISABLED', 'HTTP/2 client has disabled push streams');
+E('ERR_HTTP2_SEND_FILE', 'Only regular files can be sent');
 E('ERR_HTTP2_SOCKET_BOUND',
   'The socket is already bound to an Http2Session');
 E('ERR_HTTP2_STATUS_INVALID',
@@ -163,6 +174,8 @@ E('ERR_HTTP2_STATUS_INVALID',
 E('ERR_HTTP2_STATUS_101',
   'HTTP status code 101 (Switching Protocols) is forbidden in HTTP/2');
 E('ERR_HTTP2_STREAM_CLOSED', 'The stream is already closed');
+E('ERR_HTTP2_STREAM_ERROR',
+  (code) => `Stream closed with error code ${code}`);
 E('ERR_HTTP2_STREAM_SELF_DEPENDENCY', 'A stream cannot depend on itself');
 E('ERR_HTTP2_UNSUPPORTED_PROTOCOL',
   (protocol) => `protocol "${protocol}" is unsupported.`);

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -15,7 +15,6 @@ const { URL } = require('url');
 const { onServerStream } = require('internal/http2/compat');
 const { utcDate } = require('internal/http');
 const { _connectionListener: httpConnectionListener } = require('http');
-const { nextTick } = require('internal/process/next_tick');
 
 const {
   assertIsObject,
@@ -159,7 +158,7 @@ function onSessionHeaders(id, cat, flags, headers) {
                     'report this as a bug in Node.js');
     }
     streams.set(id, stream);
-    owner.emit('stream', stream, obj, flags);
+    process.nextTick(() => owner.emit('stream', stream, obj, flags));
   } else {
     let event;
     let status;
@@ -192,7 +191,7 @@ function onSessionHeaders(id, cat, flags, headers) {
                     'report this as a bug in Node.js');
     }
     debug(`[${sessionName(owner[kType])}] emitting stream '${event}' event`);
-    stream.emit(event, obj, flags);
+    process.nextTick(() => stream.emit(event, obj, flags));
   }
 }
 
@@ -223,7 +222,7 @@ function onSessionTrailers(id) {
     stream.emit('fetchTrailers', trailers);
     return mapToHeaders(trailers, assertValidPseudoHeaderTrailer);
   } catch (err) {
-    nextTick(this.getAsyncId(), () => stream.emit('error', err));
+    process.nextTick(() => stream.emit('error', err));
   }
 }
 
@@ -249,7 +248,7 @@ function onSessionStreamClose(id, code) {
     debug(`Closing fd ${state.fd} for stream ${id}`);
     fs.close(state.fd, (err) => {
       if (err)
-        nextTick(this.getAsyncId(), () => stream.emit('error', err));
+        process.nextTick(() => stream.emit('error', err));
     });
   }
 
@@ -262,7 +261,7 @@ function onSessionStreamClose(id, code) {
 // Called when an error event needs to be triggered
 function onSessionError(error) {
   _unrefActive(this);
-  this[kOwner].emit('error', error);
+  process.nextTick(() => this[kOwner].emit('error', error));
 }
 
 // Receives a chunk of data for a given stream and forwards it on
@@ -297,10 +296,10 @@ function onSettings(ack) {
     if (owner[kState].pendingAck > 0)
       owner[kState].pendingAck--;
     owner[kLocalSettings] = undefined;
-    owner.emit('localSettings', owner.localSettings);
+    process.nextTick(() => owner.emit('localSettings', owner.localSettings));
   } else {
     owner[kRemoteSettings] = undefined;
-    owner.emit('remoteSettings', owner.remoteSettings);
+    process.nextTick(() => owner.emit('remoteSettings', owner.remoteSettings));
   }
 }
 
@@ -315,10 +314,9 @@ function onPriority(id, parent, weight, exclusive) {
   _unrefActive(this);
   const streams = owner[kState].streams;
   const stream = streams.get(id);
-  if (stream === undefined ||
-      !stream.emit('priority', parent, weight, exclusive)) {
-    owner.emit('priority', id, parent, weight, exclusive);
-  }
+  const emitter = stream === undefined ? owner : stream;
+  process.nextTick(
+    () => emitter.emit('priority', id, parent, weight, exclusive));
 }
 
 // Called by the native layer when an error has occurred sending a
@@ -331,7 +329,7 @@ function onFrameError(id, type, code) {
   const streams = owner[kState].streams;
   const stream = streams.get(id);
   const emitter = stream !== undefined ? stream : owner;
-  nextTick(this.getAsyncId(), () => {
+  process.nextTick(() => {
     if (!emitter.emit('frameError', type, code, id)) {
       const err = new errors.Error('ERR_HTTP2_FRAME_ERROR', type, code, id);
       err.errno = code;
@@ -345,15 +343,15 @@ function onGoawayData(code, lastStreamID, buf) {
   const owner = this[kOwner];
   const state = owner[kState];
   debug(`[${sessionName(owner[kType])}] goaway data received`);
-  nextTick(this.getAsyncId(),
-           () => owner.emit('goaway', code, lastStreamID, buf));
-  // Begin tearing down the session. If we have not yet sent a GOAWAY,
-  // attempt to do so. After, destroy the session.
-  if (!state.shuttingDown && !state.shutdown) {
-    owner.shutdown({}, () => { owner.destroy(); });
-  } else {
-    owner.destroy();
-  }
+  process.nextTick(() => {
+    owner.emit('goaway', code, lastStreamID, buf);
+    // Tear down the session or destroy
+    if (!state.shuttingDown && !state.shutdown) {
+      owner.shutdown({}, () => { owner.destroy(); });
+    } else {
+      owner.destroy();
+    }
+  });
 }
 
 // Returns the padding to use per frame. The selectPadding callback is set
@@ -406,21 +404,21 @@ function requestOnConnect(headers, options) {
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      nextTick(handle.getAsyncId(), () => session.emit('error', err));
+      process.nextTick(() => session.emit('error', err));
       break;
     case NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE:
       err = new errors.Error('ERR_HTTP2_OUT_OF_STREAMS');
-      nextTick(handle.getAsyncId(), () => this.emit('error', err));
+      process.nextTick(() => this.emit('error', err));
       break;
     case NGHTTP2_ERR_INVALID_ARGUMENT:
       err = new errors.Error('ERR_HTTP2_STREAM_SELF_DEPENDENCY');
-      nextTick(handle.getAsyncId(), () => this.emit('error', err));
+      process.nextTick(() => this.emit('error', err));
       break;
     default:
       // Some other, unexpected error was returned. Emit on the session.
       if (ret < 0) {
         err = new NghttpError(ret);
-        nextTick(handle.getAsyncId(), () => session.emit('error', err));
+        process.nextTick(() => session.emit('error', err));
         break;
       }
       debug(`[${sessionName(session[kType])}] stream ${ret} initialized`);
@@ -507,7 +505,7 @@ function setupHandle(session, socket, type, options) {
         options.settings : Object.create(null);
 
     session.settings(settings);
-    session.emit('connect', session, socket);
+    process.nextTick(() => session.emit('connect', session, socket));
   };
 }
 
@@ -524,13 +522,13 @@ function submitSettings(settings) {
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      nextTick(handle.getAsyncId(), () => this.emit('error', err));
+      process.nextTick(() => this.emit('error', err));
       break;
     default:
       // Some other unexpected error was reported.
       if (ret < 0) {
         err = new NghttpError(ret);
-        nextTick(handle.getAsyncId(), () => this.emit('error', err));
+        process.nextTick(() => this.emit('error', err));
       }
   }
   debug(`[${sessionName(this[kType])}] settings complete`);
@@ -556,13 +554,13 @@ function submitPriority(stream, options) {
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      nextTick(handle.getAsyncId(), () => this.emit('error', err));
+      process.nextTick(() => this.emit('error', err));
       break;
     default:
       // Some other unexpected error was reported.
       if (ret < 0) {
         err = new NghttpError(ret);
-        nextTick(handle.getAsyncId(), () => this.emit('error', err));
+        process.nextTick(() => this.emit('error', err));
       }
   }
   debug(`[${sessionName(this[kType])}] priority complete`);
@@ -580,13 +578,13 @@ function submitRstStream(stream, code) {
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      nextTick(handle.getAsyncId(), () => this.emit('error', err));
+      process.nextTick(() => this.emit('error', err));
       break;
     default:
       // Some other unexpected error was reported.
       if (ret < 0) {
         err = new NghttpError(ret);
-        nextTick(handle.getAsyncId(), () => this.emit('error', err));
+        process.nextTick(() => this.emit('error', err));
         break;
       }
       stream.destroy();
@@ -607,10 +605,10 @@ function doShutdown(options) {
   if (ret < 0) {
     debug(`[${sessionName(this[kType])}] shutdown failed! code: ${ret}`);
     const err = new NghttpError(ret);
-    nextTick(handle.getAsyncId(), () => this.emit('error', err));
+    process.nextTick(() => this.emit('error', err));
     return;
   }
-  nextTick(handle.getAsyncId(), () => this.emit('shutdown', options));
+  process.nextTick(() => this.emit('shutdown', options));
   debug(`[${sessionName(this[kType])}] shutdown is complete`);
 }
 
@@ -850,8 +848,8 @@ class Http2Session extends EventEmitter {
                                  options.parent);
     }
 
-    if (this[kState].connecting) {
-      this.once('connect', submitPriority.bind(this, stream, options));
+    if (stream[kID] === undefined) {
+      stream.once('ready', submitPriority.bind(this, stream, options));
       return;
     }
     submitPriority.call(this, stream, options);
@@ -887,10 +885,10 @@ class Http2Session extends EventEmitter {
     debug(`[${sessionName(this[kType])}] initiating rststream for stream ` +
           `${stream[kID]}: ${code}`);
 
-    if (this[kState].connecting) {
+    if (stream[kID] === undefined) {
       debug(`[${sessionName(this[kType])}] session still connecting, queue ` +
             'rststream');
-      this.once('connect', submitRstStream.bind(this, stream, code));
+      stream.once('ready', submitRstStream.bind(this, stream, code));
       return;
     }
     submitRstStream.call(this, stream, code);
@@ -1200,7 +1198,7 @@ function streamOnSessionConnect() {
   debug(`[${sessionName(session[kType])}] session connected. emiting stream ` +
         'connect');
   this[kState].connecting = false;
-  this.emit('connect');
+  process.nextTick(() => this.emit('connect'));
 }
 
 function streamOnceReady() {
@@ -1479,9 +1477,9 @@ class Http2Stream extends Duplex {
     const code = rst ? this[kState].rstCode : NGHTTP2_NO_ERROR;
     if (code !== NGHTTP2_NO_ERROR) {
       const err = new errors.Error('ERR_HTTP2_STREAM_ERROR', code);
-      nextTick(handle.getAsyncId(), () => this.emit('error', err));
+      process.nextTick(() => this.emit('error', err));
     }
-    nextTick(handle.getAsyncId(), () => this.emit('streamClosed', code));
+    process.nextTick(() => this.emit('streamClosed', code));
     debug(`[${sessionName(session[kType])}] stream ${this[kID]} destroyed`);
     callback(err);
   }
@@ -1517,12 +1515,12 @@ function processRespondWithFD(fd, headers) {
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      nextTick(handle.getAsyncId(), () => session.emit('error', err));
+      process.nextTick(() => session.emit('error', err));
       break;
     default:
       if (ret < 0) {
         err = new NghttpError(ret);
-        nextTick(handle.getAsyncId(), this.emit('error', err));
+        process.nextTick(() => this.emit('error', err));
       }
   }
 }
@@ -1596,20 +1594,20 @@ class ServerHttp2Stream extends Http2Stream {
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        nextTick(handle.getAsyncId(), () => session.emit('error', err));
+        process.nextTick(() => session.emit('error', err));
         break;
       case NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE:
         err = new errors.Error('ERR_HTTP2_OUT_OF_STREAMS');
-        nextTick(handle.getAsyncId(), () => this.emit('error', err));
+        process.nextTick(() => this.emit('error', err));
         break;
       case NGHTTP2_ERR_STREAM_CLOSED:
         err = new errors.Error('ERR_HTTP2_STREAM_CLOSED');
-        nextTick(handle.getAsyncId(), () => this.emit('error', err));
+        process.nextTick(() => this.emit('error', err));
         break;
       default:
         if (ret <= 0) {
           err = new NghttpError(ret);
-          nextTick(handle.getAsyncId(), () => this.emit('error', err));
+          process.nextTick(() => this.emit('error', err));
           break;
         }
         debug(`[${sessionName(session[kType])}] push stream ${ret} created`);
@@ -1626,7 +1624,7 @@ class ServerHttp2Stream extends Http2Stream {
         }
 
         streams.set(ret, stream);
-        nextTick(handle.getAsyncId(), callback, stream, headers, 0);
+        process.nextTick(callback, stream, headers, 0);
     }
   }
 
@@ -1674,12 +1672,12 @@ class ServerHttp2Stream extends Http2Stream {
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        nextTick(handle.getAsyncId(), () => session.emit('error', err));
+        process.nextTick(() => session.emit('error', err));
         break;
       default:
         if (ret < 0) {
           err = new NghttpError(ret);
-          nextTick(handle.getAsyncId(), () => this.emit('error', err));
+          process.nextTick(() => this.emit('error', err));
         }
     }
   }
@@ -1729,7 +1727,6 @@ class ServerHttp2Stream extends Http2Stream {
   // file details are sent.
   respondWithFile(path, headers, options) {
     const session = this[kSession];
-    const handle = session[kHandle];
     if (this.destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
     debug(`[${sessionName(session[kType])}] initiating response for stream ` +
@@ -1765,7 +1762,7 @@ class ServerHttp2Stream extends Http2Stream {
         return;
       }
       if (err) {
-        nextTick(handle.getAsyncId(), () => this.emit('error', err));
+        process.nextTick(() => this.emit('error', err));
         return;
       }
       state.fd = fd;
@@ -1776,12 +1773,12 @@ class ServerHttp2Stream extends Http2Stream {
           return;
         }
         if (err) {
-          nextTick(handle.getAsyncId(), () => this.emit('error', err));
+          process.nextTick(() => this.emit('error', err));
           return;
         }
         if (!stat.isFile()) {
           err = new errors.Error('ERR_HTTP2_SEND_FILE');
-          nextTick(handle.getAsyncId(), () => this.emit('error', err));
+          process.nextTick(() => this.emit('error', err));
           return;
         }
 
@@ -1839,12 +1836,12 @@ class ServerHttp2Stream extends Http2Stream {
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        nextTick(handle.getAsyncId(), () => this[kSession].emit('error', err));
+        process.nextTick(() => this[kSession].emit('error', err));
         break;
       default:
         if (ret < 0) {
           err = new NghttpError(ret);
-          nextTick(handle.getAsyncId(), () => this.emit('error', err));
+          process.nextTick(() => this.emit('error', err));
         }
     }
   }
@@ -2044,9 +2041,7 @@ function connectionListener(socket) {
 
   socket[kServer] = this;
 
-  nextTick(session[kHandle].getAsyncId(), () => {
-    this.emit('session', session);
-  });
+  process.nextTick(() => this.emit('session', session));
 }
 
 function initializeOptions(options) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -8,12 +8,14 @@ const EventEmitter = require('events');
 const net = require('net');
 const tls = require('tls');
 const util = require('util');
+const fs = require('fs');
 const errors = require('internal/errors');
 const { Duplex } = require('stream');
 const { URL } = require('url');
 const { onServerStream } = require('internal/http2/compat');
 const { utcDate } = require('internal/http');
 const { _connectionListener: httpConnectionListener } = require('http');
+const { nextTick } = require('internal/process/next_tick');
 
 const {
   assertIsObject,
@@ -92,6 +94,7 @@ const {
   HTTP2_HEADER_PATH,
   HTTP2_HEADER_SCHEME,
   HTTP2_HEADER_STATUS,
+  HTTP2_HEADER_CONTENT_LENGTH,
 
   HTTP2_METHOD_GET,
   HTTP2_METHOD_HEAD,
@@ -136,7 +139,9 @@ function onSessionHeaders(id, cat, flags, headers) {
   if (stream === undefined) {
     switch (owner[kType]) {
       case NGHTTP2_SESSION_SERVER:
-        stream = new ServerHttp2Stream(owner, id, { readable: !endOfStream });
+        stream = new ServerHttp2Stream(owner, id,
+                                       { readable: !endOfStream },
+                                       obj);
         if (obj[HTTP2_HEADER_METHOD] === HTTP2_METHOD_HEAD) {
           // For head requests, there must not be a body...
           // end the writable side immediately.
@@ -144,7 +149,6 @@ function onSessionHeaders(id, cat, flags, headers) {
           const state = stream[kState];
           state.headRequest = true;
         }
-
         break;
       case NGHTTP2_SESSION_CLIENT:
         stream = new ClientHttp2Stream(owner, id, { readable: !endOfStream });
@@ -219,7 +223,7 @@ function onSessionTrailers(id) {
     stream.emit('fetchTrailers', trailers);
     return mapToHeaders(trailers, assertValidPseudoHeaderTrailer);
   } catch (err) {
-    process.nextTick(() => stream.emit('error', err));
+    nextTick(this.getAsyncId(), () => stream.emit('error', err));
   }
 }
 
@@ -237,8 +241,18 @@ function onSessionStreamClose(id, code) {
   _unrefActive(this);
   // Set the rst state for the stream
   abort(stream);
-  stream[kState].rst = true;
-  stream[kState].rstCode = code;
+  const state = stream[kState];
+  state.rst = true;
+  state.rstCode = code;
+
+  if (state.fd !== undefined) {
+    debug(`Closing fd ${state.fd} for stream ${id}`);
+    fs.close(state.fd, (err) => {
+      if (err)
+        nextTick(this.getAsyncId(), () => stream.emit('error', err));
+    });
+  }
+
   setImmediate(() => {
     stream.destroy();
     debug(`[${sessionName(owner[kType])}] stream ${id} is closed`);
@@ -316,9 +330,14 @@ function onFrameError(id, type, code) {
   _unrefActive(this);
   const streams = owner[kState].streams;
   const stream = streams.get(id);
-  if (stream !== undefined && stream.emit('frameError', type, code))
-    return;
-  owner.emit('frameError', type, code, id);
+  const emitter = stream !== undefined ? stream : owner;
+  nextTick(this.getAsyncId(), () => {
+    if (!emitter.emit('frameError', type, code, id)) {
+      const err = new errors.Error('ERR_HTTP2_FRAME_ERROR', type, code, id);
+      err.errno = code;
+      emitter.emit('error', err);
+    }
+  });
 }
 
 // Called by the native layer when a goaway frame has been received
@@ -326,7 +345,8 @@ function onGoawayData(code, lastStreamID, buf) {
   const owner = this[kOwner];
   const state = owner[kState];
   debug(`[${sessionName(owner[kType])}] goaway data received`);
-  process.nextTick(() => owner.emit('goaway', code, lastStreamID, buf));
+  nextTick(this.getAsyncId(),
+           () => owner.emit('goaway', code, lastStreamID, buf));
   // Begin tearing down the session. If we have not yet sent a GOAWAY,
   // attempt to do so. After, destroy the session.
   if (!state.shuttingDown && !state.shutdown) {
@@ -365,11 +385,12 @@ function requestOnConnect(headers, options) {
   // ret will be either the reserved stream ID (if positive)
   // or an error code (if negative)
   validatePriorityOptions(options);
-  const ret = session[kHandle].submitRequest(mapToHeaders(headers),
-                                             !!options.endStream,
-                                             options.parent | 0,
-                                             options.weight | 0,
-                                             !!options.exclusive);
+  const handle = session[kHandle];
+  const ret = handle.submitRequest(mapToHeaders(headers),
+                                   !!options.endStream,
+                                   options.parent | 0,
+                                   options.weight | 0,
+                                   !!options.exclusive);
 
   // In an error condition, one of three possible response codes will be
   // possible:
@@ -385,21 +406,21 @@ function requestOnConnect(headers, options) {
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      process.nextTick(() => session.emit('error', err));
+      nextTick(handle.getAsyncId(), () => session.emit('error', err));
       break;
     case NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE:
       err = new errors.Error('ERR_HTTP2_OUT_OF_STREAMS');
-      process.nextTick(() => this.emit('error', err));
+      nextTick(handle.getAsyncId(), () => this.emit('error', err));
       break;
     case NGHTTP2_ERR_INVALID_ARGUMENT:
       err = new errors.Error('ERR_HTTP2_STREAM_SELF_DEPENDENCY');
-      process.nextTick(() => this.emit('error', err));
+      nextTick(handle.getAsyncId(), () => this.emit('error', err));
       break;
     default:
       // Some other, unexpected error was returned. Emit on the session.
       if (ret < 0) {
         err = new NghttpError(ret);
-        process.nextTick(() => session.emit('error', err));
+        nextTick(handle.getAsyncId(), () => session.emit('error', err));
         break;
       }
       debug(`[${sessionName(session[kType])}] stream ${ret} initialized`);
@@ -497,19 +518,19 @@ function submitSettings(settings) {
   this[kLocalSettings] = undefined;
 
   updateSettingsBuffer(settings);
-
-  const ret = this[kHandle].submitSettings();
+  const handle = this[kHandle];
+  const ret = handle.submitSettings();
   let err;
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      process.nextTick(() => this.emit('error', err));
+      nextTick(handle.getAsyncId(), () => this.emit('error', err));
       break;
     default:
       // Some other unexpected error was reported.
       if (ret < 0) {
         err = new NghttpError(ret);
-        process.nextTick(() => this.emit('error', err));
+        nextTick(handle.getAsyncId(), () => this.emit('error', err));
       }
   }
   debug(`[${sessionName(this[kType])}] settings complete`);
@@ -522,8 +543,9 @@ function submitPriority(stream, options) {
   debug(`[${sessionName(this[kType])}] submitting actual priority`);
   _unrefActive(this);
 
+  const handle = this[kHandle];
   const ret =
-    this[kHandle].submitPriority(
+    handle.submitPriority(
       stream[kID],
       options.parent | 0,
       options.weight | 0,
@@ -534,13 +556,13 @@ function submitPriority(stream, options) {
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      process.nextTick(() => this.emit('error', err));
+      nextTick(handle.getAsyncId(), () => this.emit('error', err));
       break;
     default:
       // Some other unexpected error was reported.
       if (ret < 0) {
         err = new NghttpError(ret);
-        process.nextTick(() => this.emit('error', err));
+        nextTick(handle.getAsyncId(), () => this.emit('error', err));
       }
   }
   debug(`[${sessionName(this[kType])}] priority complete`);
@@ -552,18 +574,19 @@ function submitRstStream(stream, code) {
   debug(`[${sessionName(this[kType])}] submit actual rststream`);
   _unrefActive(this);
   const id = stream[kID];
-  const ret = this[kHandle].submitRstStream(id, code);
+  const handle = this[kHandle];
+  const ret = handle.submitRstStream(id, code);
   let err;
   switch (ret) {
     case NGHTTP2_ERR_NOMEM:
       err = new errors.Error('ERR_OUTOFMEMORY');
-      process.nextTick(() => this.emit('error', err));
+      nextTick(handle.getAsyncId(), () => this.emit('error', err));
       break;
     default:
       // Some other unexpected error was reported.
       if (ret < 0) {
         err = new NghttpError(ret);
-        process.nextTick(() => this.emit('error', err));
+        nextTick(handle.getAsyncId(), () => this.emit('error', err));
         break;
       }
       stream.destroy();
@@ -584,10 +607,10 @@ function doShutdown(options) {
   if (ret < 0) {
     debug(`[${sessionName(this[kType])}] shutdown failed! code: ${ret}`);
     const err = new NghttpError(ret);
-    process.nextTick(() => this.emit('error', err));
+    nextTick(handle.getAsyncId(), () => this.emit('error', err));
     return;
   }
-  process.nextTick(() => this.emit('shutdown', options));
+  nextTick(handle.getAsyncId(), () => this.emit('shutdown', options));
   debug(`[${sessionName(this[kType])}] shutdown is complete`);
 }
 
@@ -600,7 +623,7 @@ function submitShutdown(options) {
       options.graceful === true) {
     // first send a shutdown notice
     handle.submitShutdownNotice();
-    // then, on next tick, do the actual shutdown
+    // then, on flip of the event loop, do the actual shutdown
     setImmediate(doShutdown.bind(this, options));
   } else {
     doShutdown.call(this, options);
@@ -836,7 +859,7 @@ class Http2Session extends EventEmitter {
 
   // Submits an RST-STREAM frame to be sent to the remote peer. This will
   // cause the stream to be closed.
-  rstStream(stream, code) {
+  rstStream(stream, code = NGHTTP2_NO_ERROR) {
     if (this[kState].destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_SESSION');
 
@@ -1359,7 +1382,7 @@ class Http2Stream extends Duplex {
   // defer until the ready event is emitted.
   // After sending the rstStream, this.destroy() will be called making
   // the stream object no longer usable.
-  rstStream(code) {
+  rstStream(code = NGHTTP2_NO_ERROR) {
     if (this.destroyed)
       throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
     const session = this[kSession];
@@ -1424,6 +1447,7 @@ class Http2Stream extends Duplex {
   // * Then cleans up the resources on the js side
   _destroy(err, callback) {
     const session = this[kSession];
+    const handle = session[kHandle];
     if (this[kID] === undefined) {
       debug(`[${sessionName(session[kType])}] queuing destroy for new stream`);
       this.once('ready', this._destroy.bind(this, err, callback));
@@ -1444,24 +1468,71 @@ class Http2Stream extends Duplex {
     unenroll(this);
 
     setImmediate(() => {
-      if (session[kHandle] !== undefined)
-        session[kHandle].destroyStream(this[kID]);
+      if (handle !== undefined)
+        handle.destroyStream(this[kID]);
     });
     session[kState].streams.delete(this[kID]);
     delete this[kSession];
 
     // All done
-    this.emit('streamClosed',
-              this[kState].rst ? this[kState].rstCode : NGHTTP2_NO_ERROR);
+    const rst = this[kState].rst;
+    const code = rst ? this[kState].rstCode : NGHTTP2_NO_ERROR;
+    if (code !== NGHTTP2_NO_ERROR) {
+      const err = new errors.Error('ERR_HTTP2_STREAM_ERROR', code);
+      nextTick(handle.getAsyncId(), () => this.emit('error', err));
+    }
+    nextTick(handle.getAsyncId(), () => this.emit('streamClosed', code));
     debug(`[${sessionName(session[kType])}] stream ${this[kID]} destroyed`);
     callback(err);
   }
 }
 
+function processHeaders(headers) {
+  assertIsObject(headers, 'headers');
+  headers = Object.assign(Object.create(null), headers);
+  if (headers[HTTP2_HEADER_STATUS] == null)
+    headers[HTTP2_HEADER_STATUS] = HTTP_STATUS_OK;
+  headers[HTTP2_HEADER_DATE] = utcDate();
+
+  const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
+  if (statusCode < 200 || statusCode > 999)
+    throw new errors.RangeError('ERR_HTTP2_STATUS_INVALID',
+                                headers[HTTP2_HEADER_STATUS]);
+
+  return headers;
+}
+
+function processRespondWithFD(fd, headers) {
+  const session = this[kSession];
+  const state = this[kState];
+  state.headersSent = true;
+
+  // Close the writable side of the stream
+  this.end();
+
+  const handle = session[kHandle];
+  const ret =
+    handle.submitFile(this[kID], fd, headers);
+  let err;
+  switch (ret) {
+    case NGHTTP2_ERR_NOMEM:
+      err = new errors.Error('ERR_OUTOFMEMORY');
+      nextTick(handle.getAsyncId(), () => session.emit('error', err));
+      break;
+    default:
+      if (ret < 0) {
+        err = new NghttpError(ret);
+        nextTick(handle.getAsyncId(), this.emit('error', err));
+      }
+  }
+}
+
 class ServerHttp2Stream extends Http2Stream {
-  constructor(session, id, options) {
+  constructor(session, id, options, headers) {
     super(session, options);
     this[kInit](id);
+    this[kProtocol] = headers[HTTP2_HEADER_SCHEME];
+    this[kAuthority] = headers[HTTP2_HEADER_AUTHORITY];
     debug(`[${sessionName(session[kType])}] created serverhttp2stream`);
   }
 
@@ -1506,9 +1577,9 @@ class ServerHttp2Stream extends Http2Stream {
     if (headers[HTTP2_HEADER_METHOD] === undefined)
       headers[HTTP2_HEADER_METHOD] = HTTP2_METHOD_GET;
     if (headers[HTTP2_HEADER_AUTHORITY] === undefined)
-      headers[HTTP2_HEADER_AUTHORITY] = session[kAuthority];
+      headers[HTTP2_HEADER_AUTHORITY] = this[kAuthority];
     if (headers[HTTP2_HEADER_SCHEME] === undefined)
-      headers[HTTP2_HEADER_SCHEME] = session[kProtocol].slice(0, -1);
+      headers[HTTP2_HEADER_SCHEME] = this[kProtocol];
     if (headers[HTTP2_HEADER_PATH] === undefined)
       headers[HTTP2_HEADER_PATH] = '/';
 
@@ -1525,25 +1596,26 @@ class ServerHttp2Stream extends Http2Stream {
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        process.nextTick(() => session.emit('error', err));
+        nextTick(handle.getAsyncId(), () => session.emit('error', err));
         break;
       case NGHTTP2_ERR_STREAM_ID_NOT_AVAILABLE:
         err = new errors.Error('ERR_HTTP2_OUT_OF_STREAMS');
-        process.nextTick(() => this.emit('error', err));
+        nextTick(handle.getAsyncId(), () => this.emit('error', err));
         break;
       case NGHTTP2_ERR_STREAM_CLOSED:
         err = new errors.Error('ERR_HTTP2_STREAM_CLOSED');
-        process.nextTick(() => this.emit('error', err));
+        nextTick(handle.getAsyncId(), () => this.emit('error', err));
         break;
       default:
         if (ret <= 0) {
           err = new NghttpError(ret);
-          process.nextTick(() => this.emit('error', err));
+          nextTick(handle.getAsyncId(), () => this.emit('error', err));
           break;
         }
         debug(`[${sessionName(session[kType])}] push stream ${ret} created`);
         options.readable = !options.endStream;
-        const stream = new ServerHttp2Stream(session, ret, options);
+
+        const stream = new ServerHttp2Stream(session, ret, options, headers);
 
         // If the push stream is a head request, close the writable side of
         // the stream immediately as there won't be any data sent.
@@ -1554,7 +1626,7 @@ class ServerHttp2Stream extends Http2Stream {
         }
 
         streams.set(ret, stream);
-        process.nextTick(callback, stream, headers, 0);
+        nextTick(handle.getAsyncId(), callback, stream, headers, 0);
     }
   }
 
@@ -1568,58 +1640,164 @@ class ServerHttp2Stream extends Http2Stream {
     _unrefActive(this);
     const state = this[kState];
 
+    if (state.headersSent)
+      throw new errors.Error('ERR_HTTP2_HEADERS_SENT');
+
     assertIsObject(options, 'options');
     options = Object.assign(Object.create(null), options);
     options.endStream = !!options.endStream;
 
-    assertIsObject(headers, 'headers');
-    headers = Object.assign(Object.create(null), headers);
-    if (headers[HTTP2_HEADER_STATUS] == null) {
-      headers[HTTP2_HEADER_STATUS] = HTTP_STATUS_OK;
-    } else {
-      const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
-      if (statusCode < 200 || statusCode > 999)
-        throw new errors.RangeError('ERR_HTTP2_STATUS_INVALID',
-                                    headers[HTTP2_HEADER_STATUS]);
+    headers = processHeaders(headers);
+    const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
 
-      // Payload/DATA frames are not permitted in these cases so set
-      // the options.endStream option to true so that the underlying
-      // bits do not attempt to send any.
-      if (statusCode === HTTP_STATUS_NO_CONTENT ||
-          statusCode === HTTP_STATUS_CONTENT_RESET ||
-          statusCode === HTTP_STATUS_NOT_MODIFIED ||
-          state.headRequest === true) {
-        options.endStream = true;
-      }
+    // Payload/DATA frames are not permitted in these cases so set
+    // the options.endStream option to true so that the underlying
+    // bits do not attempt to send any.
+    if (statusCode === HTTP_STATUS_NO_CONTENT ||
+        statusCode === HTTP_STATUS_CONTENT_RESET ||
+        statusCode === HTTP_STATUS_NOT_MODIFIED ||
+        state.headRequest === true) {
+      options.endStream = true;
     }
-    headers[HTTP2_HEADER_DATE] = utcDate();
 
-    if (state.headersSent)
-      throw new errors.Error('ERR_HTTP2_HEADERS_SENT');
+    const headersList = mapToHeaders(headers, assertValidPseudoHeaderResponse);
+    state.headersSent = true;
 
     // Close the writable side if the endStream option is set
     if (options.endStream)
       this.end();
 
+    const handle = session[kHandle];
     const ret =
-      this[kSession][kHandle].submitResponse(
-        this[kID],
-        mapToHeaders(headers, assertValidPseudoHeaderResponse),
-        options.endStream);
+      handle.submitResponse(this[kID], headersList, options.endStream);
     let err;
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        process.nextTick(() => this[kSession].emit('error', err));
+        nextTick(handle.getAsyncId(), () => session.emit('error', err));
         break;
       default:
         if (ret < 0) {
           err = new NghttpError(ret);
-          process.nextTick(() => this.emit('error', err));
+          nextTick(handle.getAsyncId(), () => this.emit('error', err));
+        }
+    }
+  }
+
+  // Initiate a response using an open FD. Note that there are fewer
+  // protections with this approach. For one, the fd is not validated.
+  // In respondWithFile, the file is checked to make sure it is a
+  // regular file, here the fd is passed directly. If the underlying
+  // mechanism is not able to read from the fd, then the stream will be
+  // reset with an error code.
+  respondWithFD(fd, headers) {
+    const session = this[kSession];
+    if (this.destroyed)
+      throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
+    debug(`[${sessionName(session[kType])}] initiating response for stream ` +
+          `${this[kID]}`);
+    _unrefActive(this);
+    const state = this[kState];
+
+    if (state.headersSent)
+      throw new errors.Error('ERR_HTTP2_HEADERS_SENT');
+
+    if (typeof fd !== 'number')
+      throw new errors.TypeError('ERR_INVALID_ARG_TYPE',
+                                 'fd', 'number');
+
+    headers = processHeaders(headers);
+    const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
+    // Payload/DATA frames are not permitted in these cases
+    if (statusCode === HTTP_STATUS_NO_CONTENT ||
+        statusCode === HTTP_STATUS_CONTENT_RESET ||
+        statusCode === HTTP_STATUS_NOT_MODIFIED) {
+      throw new errors.Error('ERR_HTTP2_PAYLOAD_FORBIDDEN', statusCode);
+    }
+
+    processRespondWithFD.call(this, fd,
+                              mapToHeaders(headers,
+                                           assertValidPseudoHeaderResponse));
+  }
+
+  // Initiate a file response on this Http2Stream. The path is passed to
+  // fs.open() to acquire the fd with mode 'r', then the fd is passed to
+  // fs.fstat(). Assuming fstat is successful, a check is made to ensure
+  // that the file is a regular file, then options.statCheck is called,
+  // giving the user an opportunity to verify the details and set additional
+  // headers. If statCheck returns false, the operation is aborted and no
+  // file details are sent.
+  respondWithFile(path, headers, options) {
+    const session = this[kSession];
+    const handle = session[kHandle];
+    if (this.destroyed)
+      throw new errors.Error('ERR_HTTP2_INVALID_STREAM');
+    debug(`[${sessionName(session[kType])}] initiating response for stream ` +
+          `${this[kID]}`);
+    _unrefActive(this);
+    const state = this[kState];
+
+    if (state.headersSent)
+      throw new errors.Error('ERR_HTTP2_HEADERS_SENT');
+
+    assertIsObject(options, 'options');
+    options = Object.assign(Object.create(null), options);
+
+    if (options.statCheck !== undefined &&
+        typeof options.statCheck !== 'function') {
+      throw new errors.TypeError('ERR_INVALID_OPT_VALUE',
+                                 'statCheck',
+                                 options.statCheck);
+    }
+
+    headers = processHeaders(headers);
+    const statusCode = headers[HTTP2_HEADER_STATUS] |= 0;
+    // Payload/DATA frames are not permitted in these cases
+    if (statusCode === HTTP_STATUS_NO_CONTENT ||
+        statusCode === HTTP_STATUS_CONTENT_RESET ||
+        statusCode === HTTP_STATUS_NOT_MODIFIED) {
+      throw new errors.Error('ERR_HTTP2_PAYLOAD_FORBIDDEN', statusCode);
+    }
+
+    fs.open(path, 'r', (err, fd) => {
+      if (this.destroyed || session.destroyed) {
+        abort(this);
+        return;
+      }
+      if (err) {
+        nextTick(handle.getAsyncId(), () => this.emit('error', err));
+        return;
+      }
+      state.fd = fd;
+
+      fs.fstat(fd, (err, stat) => {
+        if (this.destroyed || session.destroyed) {
+          abort(this);
           return;
         }
-        state.headersSent = true;
-    }
+        if (err) {
+          nextTick(handle.getAsyncId(), () => this.emit('error', err));
+          return;
+        }
+        if (!stat.isFile()) {
+          err = new errors.Error('ERR_HTTP2_SEND_FILE');
+          nextTick(handle.getAsyncId(), () => this.emit('error', err));
+          return;
+        }
+
+        // Set the content-length by default
+        headers[HTTP2_HEADER_CONTENT_LENGTH] = stat.size;
+        if (typeof options.statCheck === 'function' &&
+            options.statCheck.call(this, stat, headers) === false) {
+          return;
+        }
+
+        const headersList = mapToHeaders(headers,
+                                         assertValidPseudoHeaderResponse);
+
+        processRespondWithFD.call(this, fd, headersList);
+      });
+    });
   }
 
   // Sends a block of informational headers. In theory, the HTTP/2 spec
@@ -1661,12 +1839,12 @@ class ServerHttp2Stream extends Http2Stream {
     switch (ret) {
       case NGHTTP2_ERR_NOMEM:
         err = new errors.Error('ERR_OUTOFMEMORY');
-        process.nextTick(() => this[kSession].emit('error', err));
+        nextTick(handle.getAsyncId(), () => this[kSession].emit('error', err));
         break;
       default:
         if (ret < 0) {
           err = new NghttpError(ret);
-          process.nextTick(() => this.emit('error', err));
+          nextTick(handle.getAsyncId(), () => this.emit('error', err));
         }
     }
   }
@@ -1866,7 +2044,7 @@ function connectionListener(socket) {
 
   socket[kServer] = this;
 
-  process.nextTick(() => {
+  nextTick(session[kHandle].getAsyncId(), () => {
     this.emit('session', session);
   });
 }

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -156,12 +156,7 @@ ssize_t Http2Session::OnCallbackPadding(size_t frameLen,
     uint32_t* buffer = env()->http2_padding_buffer();
     buffer[0] = frameLen;
     buffer[1] = maxPayloadLen;
-    v8::TryCatch try_catch(isolate);
-    Local<Value> ret = MakeCallback(env()->ongetpadding_string(), 0, nullptr);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(isolate, try_catch);
-    }
+    MakeCallback(env()->ongetpadding_string(), 0, nullptr);
     uint32_t retval = buffer[2];
     retval = retval <= maxPayloadLen ? retval : maxPayloadLen;
     retval = retval >= frameLen ? retval : frameLen;
@@ -857,13 +852,9 @@ void Http2Session::OnTrailers(Nghttp2Stream* stream,
       Integer::New(isolate, stream->id())
     };
 
-    v8::TryCatch try_catch(isolate);
     Local<Value> ret = MakeCallback(env()->ontrailers_string(),
                                     arraysize(argv), argv);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(isolate, try_catch);
-    } else {
+    if (!ret.IsEmpty()) {
       if (ret->IsArray()) {
         Local<Array> headers = ret.As<Array>();
         if (headers->Length() > 0) {
@@ -924,13 +915,7 @@ void Http2Session::OnHeaders(Nghttp2Stream* stream,
       Integer::New(isolate, flags),
       holder
     };
-    v8::TryCatch try_catch(isolate);
-    Local<Value> ret = MakeCallback(env()->onheaders_string(),
-                                    arraysize(argv), argv);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(isolate, try_catch);
-    }
+    MakeCallback(env()->onheaders_string(), arraysize(argv), argv);
   }
 }
 
@@ -945,13 +930,7 @@ void Http2Session::OnStreamClose(int32_t id, uint32_t code) {
       Integer::New(isolate, id),
       Integer::NewFromUnsigned(isolate, code)
     };
-    v8::TryCatch try_catch(isolate);
-    Local<Value> ret = MakeCallback(env()->onstreamclose_string(),
-                                    arraysize(argv), argv);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(isolate, try_catch);
-    }
+    MakeCallback(env()->onstreamclose_string(), arraysize(argv), argv);
   }
 }
 
@@ -985,14 +964,8 @@ void Http2Session::OnSettings(bool ack) {
   HandleScope scope(isolate);
   Context::Scope context_scope(context);
   if (object()->Has(context, env()->onsettings_string()).FromJust()) {
-    v8::TryCatch try_catch(isolate);
     Local<Value> argv[1] = { Boolean::New(isolate, ack) };
-    Local<Value> ret = MakeCallback(env()->onsettings_string(),
-                                    arraysize(argv), argv);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(isolate, try_catch);
-    }
+    MakeCallback(env()->onsettings_string(), arraysize(argv), argv);
   }
 }
 
@@ -1002,18 +975,12 @@ void Http2Session::OnFrameError(int32_t id, uint8_t type, int error_code) {
   HandleScope scope(isolate);
   Context::Scope context_scope(context);
   if (object()->Has(context, env()->onframeerror_string()).FromJust()) {
-    v8::TryCatch try_catch(isolate);
     Local<Value> argv[3] = {
       Integer::New(isolate, id),
       Integer::New(isolate, type),
       Integer::New(isolate, error_code)
     };
-    Local<Value> ret = MakeCallback(env()->onframeerror_string(),
-                                    arraysize(argv), argv);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(isolate, try_catch);
-    }
+    MakeCallback(env()->onframeerror_string(), arraysize(argv), argv);
   }
 }
 
@@ -1026,19 +993,13 @@ void Http2Session::OnPriority(int32_t stream,
   HandleScope scope(isolate);
   Context::Scope context_scope(context);
   if (object()->Has(context, env()->onpriority_string()).FromJust()) {
-    v8::TryCatch try_catch(isolate);
     Local<Value> argv[4] = {
       Integer::New(isolate, stream),
       Integer::New(isolate, parent),
       Integer::New(isolate, weight),
       Boolean::New(isolate, exclusive)
     };
-    Local<Value> ret = MakeCallback(env()->onpriority_string(),
-                                    arraysize(argv), argv);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(isolate, try_catch);
-    }
+    MakeCallback(env()->onpriority_string(), arraysize(argv), argv);
   }
 }
 
@@ -1051,7 +1012,6 @@ void Http2Session::OnGoAway(int32_t lastStreamID,
   HandleScope scope(isolate);
   Context::Scope context_scope(context);
   if (object()->Has(context, env()->ongoawaydata_string()).FromJust()) {
-    v8::TryCatch try_catch(isolate);
     Local<Value> argv[3] = {
       Integer::NewFromUnsigned(isolate, errorCode),
       Integer::New(isolate, lastStreamID),
@@ -1064,12 +1024,7 @@ void Http2Session::OnGoAway(int32_t lastStreamID,
                              length).ToLocalChecked();
     }
 
-    Local<Value> ret = MakeCallback(env()->ongoawaydata_string(),
-                                    arraysize(argv), argv);
-    if (ret.IsEmpty()) {
-      ClearFatalExceptionHandlers(env());
-      FatalException(isolate, try_catch);
-    }
+    MakeCallback(env()->ongoawaydata_string(), arraysize(argv), argv);
   }
 }
 

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -434,6 +434,7 @@ class Http2Session : public AsyncWrap,
   static void SubmitSettings(const FunctionCallbackInfo<Value>& args);
   static void SubmitRstStream(const FunctionCallbackInfo<Value>& args);
   static void SubmitResponse(const FunctionCallbackInfo<Value>& args);
+  static void SubmitFile(const FunctionCallbackInfo<Value>& args);
   static void SubmitRequest(const FunctionCallbackInfo<Value>& args);
   static void SubmitPushPromise(const FunctionCallbackInfo<Value>& args);
   static void SubmitPriority(const FunctionCallbackInfo<Value>& args);

--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -417,6 +417,19 @@ inline int Nghttp2Stream::SubmitResponse(nghttp2_nv* nva,
                                  nva, len, provider);
 }
 
+// Initiate a response that contains data read from a file descriptor.
+inline int Nghttp2Stream::SubmitFile(int fd, nghttp2_nv* nva, size_t len) {
+  CHECK_GT(len, 0);
+  CHECK_GT(fd, 0);
+  DEBUG_HTTP2("Nghttp2Stream %d: submitting file\n", id_);
+  nghttp2_data_provider prov;
+  prov.source.ptr = this;
+  prov.source.fd = fd;
+  prov.read_callback = Nghttp2Session::OnStreamReadFD;
+
+  return nghttp2_submit_response(session_->session(), id_,
+                                 nva, len, &prov);
+}
 
 // Initiate a request. If writable is true (the default), then
 // an nghttp2_data_provider will be initialized, causing at

--- a/src/node_http2_core.cc
+++ b/src/node_http2_core.cc
@@ -102,7 +102,9 @@ int Nghttp2Session::OnFrameNotSent(nghttp2_session* session,
   DEBUG_HTTP2("Nghttp2Session %d: frame type %d was not sent, code: %d\n",
               handle->session_type_, frame->hd.type, error_code);
   // Do not report if the frame was not sent due to the session closing
-  if (error_code != NGHTTP2_ERR_SESSION_CLOSING)
+  if (error_code != NGHTTP2_ERR_SESSION_CLOSING &&
+      error_code != NGHTTP2_ERR_STREAM_CLOSED &&
+      error_code != NGHTTP2_ERR_STREAM_CLOSING)
     handle->OnFrameError(frame->hd.stream_id, frame->hd.type, error_code);
   return 0;
 }

--- a/src/node_http2_core.h
+++ b/src/node_http2_core.h
@@ -208,7 +208,13 @@ class Nghttp2Session {
                                  const uint8_t *data,
                                  size_t len,
                                  void* user_data);
-
+  static ssize_t OnStreamReadFD(nghttp2_session* session,
+                                int32_t id,
+                                uint8_t* buf,
+                                size_t length,
+                                uint32_t* flags,
+                                nghttp2_data_source* source,
+                                void* user_data);
   static ssize_t OnStreamRead(nghttp2_session* session,
                               int32_t id,
                               uint8_t* buf,
@@ -299,6 +305,9 @@ class Nghttp2Stream {
   inline int SubmitResponse(nghttp2_nv* nva,
                             size_t len,
                             bool emptyPayload = false);
+
+  // Send data read from a file descriptor as the response on this stream.
+  inline int SubmitFile(int fd, nghttp2_nv* nva, size_t len);
 
   // Submit informational headers for this stream
   inline int SubmitInfo(nghttp2_nv* nva, size_t len);
@@ -408,6 +417,7 @@ class Nghttp2Stream {
   nghttp2_stream_write_queue* queue_tail_ = nullptr;
   unsigned int queue_head_index_ = 0;
   size_t queue_head_offset_ = 0;
+  size_t fd_offset_ = 0;
 
   // The Current Headers block... As headers are received for this stream,
   // they are temporarily stored here until the OnFrameReceived is called

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -790,3 +790,12 @@ exports.hijackStdout = hijackStdWritable.bind(null, 'stdout');
 exports.hijackStderr = hijackStdWritable.bind(null, 'stderr');
 exports.restoreStdout = restoreWritable.bind(null, 'stdout');
 exports.restoreStderr = restoreWritable.bind(null, 'stderr');
+
+let fd = 2;
+exports.firstInvalidFD = function firstInvalidFD() {
+  // Get first known bad file descriptor.
+  try {
+    while (fs.fstatSync(++fd));
+  } catch (e) {}
+  return fd;
+};

--- a/test/parallel/test-http2-client-stream-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-stream-destroy-before-connect.js
@@ -14,7 +14,7 @@ const server = h2.createServer();
 server.on('stream', (stream) => {
   stream.on('error', common.expectsError({
     code: 'ERR_HTTP2_STREAM_ERROR',
-    type: 'Error',
+    type: Error,
     message: 'Stream closed with error code 2'
   }));
   stream.respond({});

--- a/test/parallel/test-http2-client-stream-destroy-before-connect.js
+++ b/test/parallel/test-http2-client-stream-destroy-before-connect.js
@@ -8,6 +8,19 @@ const NGHTTP2_INTERNAL_ERROR = h2.constants.NGHTTP2_INTERNAL_ERROR;
 
 const server = h2.createServer();
 
+// Do not mustCall the server side callbacks, they may or may not be called
+// depending on the OS. The determination is based largely on operating
+// system specific timings
+server.on('stream', (stream) => {
+  stream.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    type: 'Error',
+    message: 'Stream closed with error code 2'
+  }));
+  stream.respond({});
+  stream.end();
+});
+
 server.listen(0);
 
 server.on('listening', common.mustCall(() => {
@@ -19,8 +32,19 @@ server.on('listening', common.mustCall(() => {
   req.destroy(err);
 
   req.on('error', common.mustCall((e) => {
-    assert.strictEqual(e, err);
-  }));
+    if (e.code === 'ERR_HTTP2_STREAM_ERROR') {
+      common.expectsError({
+        code: 'ERR_HTTP2_STREAM_ERROR',
+        type: Error,
+        message: 'Stream closed with error code 2'
+      });
+    } else {
+      common.expectsError({
+        type: Error,
+        message: 'test'
+      });
+    }
+  }, 2));
 
   req.on('streamClosed', common.mustCall((code) => {
     assert.strictEqual(req.rstCode, NGHTTP2_INTERNAL_ERROR);
@@ -32,4 +56,5 @@ server.on('listening', common.mustCall(() => {
   req.on('response', common.mustNotCall());
   req.resume();
   req.on('end', common.mustCall());
+
 }));

--- a/test/parallel/test-http2-goaway-opaquedata.js
+++ b/test/parallel/test-http2-goaway-opaquedata.js
@@ -14,6 +14,11 @@ server.on('stream', common.mustCall((stream) => {
     opaqueData: data
   });
   stream.end();
+  stream.on('error', common.mustCall(common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    type: Error,
+    message: 'Stream closed with error code 7'
+  })));
 }));
 
 server.listen(0, () => {

--- a/test/parallel/test-http2-max-concurrent-streams.js
+++ b/test/parallel/test-http2-max-concurrent-streams.js
@@ -58,5 +58,10 @@ server.on('listening', common.mustCall(() => {
   req2.on('response', common.mustNotCall());
   req2.resume();
   req2.on('end', onEnd);
+  req2.on('error', common.mustCall(common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    type: Error,
+    message: 'Stream closed with error code 7'
+  })));
 
 }));

--- a/test/parallel/test-http2-options-max-reserved-streams.js
+++ b/test/parallel/test-http2-options-max-reserved-streams.js
@@ -31,6 +31,11 @@ server.on('stream', common.mustCall((stream) => {
   }, common.mustCall((pushedStream) => {
     pushedStream.respond({ ':status': 200 });
     pushedStream.on('aborted', common.mustCall());
+    pushedStream.on('error', common.mustCall(common.expectsError({
+      code: 'ERR_HTTP2_STREAM_ERROR',
+      type: Error,
+      message: 'Stream closed with error code 8'
+    })));
   }));
 
   stream.end('hello world');
@@ -39,10 +44,6 @@ server.listen(0);
 
 server.on('listening', common.mustCall(() => {
 
-  // Setting the maxSendHeaderBlockLength, then attempting to send a
-  // headers block that is too big should cause a 'frameError' to
-  // be emitted, and will cause the stream to be shutdown automatically
-  // without the js layer being notified at all.
   const options = {
     maxReservedRemoteStreams: 1
   };

--- a/test/parallel/test-http2-priority-event.js
+++ b/test/parallel/test-http2-priority-event.js
@@ -37,9 +37,6 @@ server.on('priority', common.mustCall(onPriority));
 server.on('listening', common.mustCall(() => {
 
   const client = h2.connect(`http://localhost:${server.address().port}`);
-
-  client.on('priority', common.mustCall(onPriority));
-
   const req = client.request({ ':path': '/'});
 
   client.on('connect', () => {
@@ -49,6 +46,8 @@ server.on('listening', common.mustCall(() => {
       exclusive: false
     });
   });
+
+  req.on('priority', common.mustCall(onPriority));
 
   req.on('response', common.mustCall());
   req.on('data', common.noop);

--- a/test/parallel/test-http2-respond-file-204.js
+++ b/test/parallel/test-http2-respond-file-204.js
@@ -1,0 +1,41 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const http2 = require('http2');
+const assert = require('assert');
+const path = require('path');
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_STATUS
+} = http2.constants;
+
+const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  assert.throws(() => {
+    stream.respondWithFile(fname, {
+      [HTTP2_HEADER_STATUS]: 204,
+      [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
+    });
+  }, common.expectsError({
+    code: 'ERR_HTTP2_PAYLOAD_FORBIDDEN',
+    type: Error,
+    message: 'Responses with 204 status must not have a payload'
+  }));
+  stream.respond({});
+  stream.end();
+});
+server.listen(0, () => {
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+  req.on('response', common.mustCall());
+  req.on('data', common.mustNotCall());
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+});

--- a/test/parallel/test-http2-respond-file-304.js
+++ b/test/parallel/test-http2-respond-file-304.js
@@ -1,0 +1,44 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const http2 = require('http2');
+const assert = require('assert');
+const path = require('path');
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_STATUS
+} = http2.constants;
+
+const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  stream.respondWithFile(fname, {
+    [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
+  }, {
+    statCheck(stat, headers) {
+      // abort the send and return a 304 Not Modified instead
+      stream.respond({ [HTTP2_HEADER_STATUS]: 304 });
+      return false;
+    }
+  });
+});
+server.listen(0, () => {
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[HTTP2_HEADER_STATUS], 304);
+    assert.strictEqual(headers[HTTP2_HEADER_CONTENT_TYPE, undefined]);
+  }));
+
+  req.on('data', common.mustNotCall());
+  req.on('end', common.mustCall(() => {
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+});

--- a/test/parallel/test-http2-respond-file-fd-invalid.js
+++ b/test/parallel/test-http2-respond-file-fd-invalid.js
@@ -1,0 +1,37 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const http2 = require('http2');
+const assert = require('assert');
+
+const {
+  NGHTTP2_INTERNAL_ERROR
+} = http2.constants;
+
+const errorCheck = common.expectsError({
+  code: 'ERR_HTTP2_STREAM_ERROR',
+  type: Error,
+  message: `Stream closed with error code ${NGHTTP2_INTERNAL_ERROR}`
+});
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  stream.respondWithFD(common.firstInvalidFD());
+  stream.on('error', common.mustCall(errorCheck));
+});
+server.listen(0, () => {
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+
+  req.on('response', common.mustCall());
+  req.on('error', common.mustCall(errorCheck));
+  req.on('data', common.mustNotCall());
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(req.rstCode, NGHTTP2_INTERNAL_ERROR);
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+});

--- a/test/parallel/test-http2-respond-file-fd.js
+++ b/test/parallel/test-http2-respond-file-fd.js
@@ -1,0 +1,46 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const http2 = require('http2');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_CONTENT_LENGTH
+} = http2.constants;
+
+const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const data = fs.readFileSync(fname);
+const stat = fs.statSync(fname);
+const fd = fs.openSync(fname, 'r');
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  stream.respondWithFD(fd, {
+    [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain',
+    [HTTP2_HEADER_CONTENT_LENGTH]: stat.size,
+  });
+});
+server.on('close', common.mustCall(() => fs.closeSync(fd)));
+server.listen(0, () => {
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+
+  req.on('response', common.mustCall((headers) => {
+    assert.strictEqual(headers[HTTP2_HEADER_CONTENT_TYPE], 'text/plain');
+    assert.strictEqual(+headers[HTTP2_HEADER_CONTENT_LENGTH], data.length);
+  }));
+  req.setEncoding('utf8');
+  let check = '';
+  req.on('data', (chunk) => check += chunk);
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(check, data.toString('utf8'));
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+});

--- a/test/parallel/test-http2-respond-file-push.js
+++ b/test/parallel/test-http2-respond-file-push.js
@@ -1,0 +1,81 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const http2 = require('http2');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_CONTENT_LENGTH,
+  HTTP2_HEADER_LAST_MODIFIED
+} = http2.constants;
+
+const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const data = fs.readFileSync(fname);
+const stat = fs.statSync(fname);
+const fd = fs.openSync(fname, 'r');
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  stream.respond({});
+  stream.end();
+
+  stream.pushStream({
+    ':path': '/file.txt',
+    ':method': 'GET'
+  }, (stream) => {
+    stream.respondWithFD(fd, {
+      [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain',
+      [HTTP2_HEADER_CONTENT_LENGTH]: stat.size,
+      [HTTP2_HEADER_LAST_MODIFIED]: stat.mtime.toUTCString()
+    });
+  });
+
+  stream.end();
+});
+
+server.on('close', common.mustCall(() => fs.closeSync(fd)));
+
+server.listen(0, () => {
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  let expected = 2;
+  function maybeClose() {
+    if (--expected === 0) {
+      server.close();
+      client.destroy();
+    }
+  }
+
+  const req = client.request({});
+
+  req.on('response', common.mustCall());
+
+  client.on('stream', common.mustCall((stream, headers) => {
+
+    stream.on('push', common.mustCall((headers) => {
+      assert.strictEqual(headers[HTTP2_HEADER_CONTENT_TYPE], 'text/plain');
+      assert.strictEqual(+headers[HTTP2_HEADER_CONTENT_LENGTH], data.length);
+      assert.strictEqual(headers[HTTP2_HEADER_LAST_MODIFIED],
+                         stat.mtime.toUTCString());
+    }));
+
+    stream.setEncoding('utf8');
+    let check = '';
+    stream.on('data', (chunk) => check += chunk);
+    stream.on('end', common.mustCall(() => {
+      assert.strictEqual(check, data.toString('utf8'));
+      maybeClose();
+    }));
+
+  }));
+
+  req.resume();
+  req.on('end', maybeClose);
+
+  req.end();
+});

--- a/test/parallel/test-http2-respond-file.js
+++ b/test/parallel/test-http2-respond-file.js
@@ -1,0 +1,52 @@
+// Flags: --expose-http2
+'use strict';
+
+const common = require('../common');
+const http2 = require('http2');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+const {
+  HTTP2_HEADER_CONTENT_TYPE,
+  HTTP2_HEADER_CONTENT_LENGTH,
+  HTTP2_HEADER_LAST_MODIFIED
+} = http2.constants;
+
+const fname = path.resolve(common.fixturesDir, 'elipses.txt');
+const data = fs.readFileSync(fname);
+const stat = fs.statSync(fname);
+
+const server = http2.createServer();
+server.on('stream', (stream) => {
+  stream.respondWithFile(fname, {
+    [HTTP2_HEADER_CONTENT_TYPE]: 'text/plain'
+  }, {
+    statCheck(stat, headers) {
+      headers[HTTP2_HEADER_LAST_MODIFIED] = stat.mtime.toUTCString();
+      headers[HTTP2_HEADER_CONTENT_LENGTH] = stat.size;
+    }
+  });
+});
+server.listen(0, () => {
+
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+
+  req.on('response', common.mustCall((headers) => {
+    console.log(headers);
+    assert.strictEqual(headers[HTTP2_HEADER_CONTENT_TYPE], 'text/plain');
+    assert.strictEqual(+headers[HTTP2_HEADER_CONTENT_LENGTH], data.length);
+    assert.strictEqual(headers[HTTP2_HEADER_LAST_MODIFIED],
+                       stat.mtime.toUTCString());
+  }));
+  req.setEncoding('utf8');
+  let check = '';
+  req.on('data', (chunk) => check += chunk);
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(check, data.toString('utf8'));
+    client.destroy();
+    server.close();
+  }));
+  req.end();
+});

--- a/test/parallel/test-http2-server-destroy-before-write.js
+++ b/test/parallel/test-http2-server-destroy-before-write.js
@@ -14,8 +14,8 @@ function onStream(stream, headers, flags) {
   stream.session.destroy();
   assert.throws(() => stream.write('data'),
                 common.expectsError({
-                  type: Error,
-                  message: /^write after end$/
+                  code: 'ERR_HTTP2_INVALID_STREAM',
+                  type: Error
                 }));
 }
 

--- a/test/parallel/test-http2-server-rst-before-respond.js
+++ b/test/parallel/test-http2-server-rst-before-respond.js
@@ -11,7 +11,7 @@ const server = h2.createServer();
 server.on('stream', common.mustCall(onStream));
 
 function onStream(stream, headers, flags) {
-  stream.rstWithCancel();
+  stream.rstStream();
 
   assert.throws(() => {
     stream.additionalHeaders({
@@ -35,7 +35,7 @@ server.on('listening', common.mustCall(() => {
   req.on('headers', common.mustNotCall());
 
   req.on('streamClosed', common.mustCall((code) => {
-    assert.strictEqual(h2.constants.NGHTTP2_CANCEL, code);
+    assert.strictEqual(h2.constants.NGHTTP2_NO_ERROR, code);
     server.close();
     client.destroy();
   }));

--- a/test/parallel/test-http2-server-shutdown-before-respond.js
+++ b/test/parallel/test-http2-server-shutdown-before-respond.js
@@ -29,5 +29,4 @@ server.on('listening', common.mustCall(() => {
   req.resume();
   req.on('end', common.mustCall(() => server.close()));
   req.end();
-
 }));


### PR DESCRIPTION
Adds a new `http2stream.respondWithFile()` method that allows
sending a file in response without having to go through the
streams mechanism. All of the file i/o happens in the native
layer.

See the docs and test for an example.

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
http2