### PR TITLE
http2: make ncopy signed

### DIFF
--- a/src/node_http2_core-inl.h
+++ b/src/node_http2_core-inl.h
@@ -134,7 +134,7 @@ inline void Nghttp2Session::HandleGoawayFrame(const nghttp2_frame* frame) {
 inline void Nghttp2Session::SendPendingData() {
   const uint8_t* data;
   ssize_t len = 0;
-  ssize_t ncopy = 0;
+  size_t ncopy = 0;
   uv_buf_t buf;
   AllocateSend(SEND_BUFFER_RECOMMENDED_SIZE, &buf);
   while (nghttp2_session_want_write(session_)) {


### PR DESCRIPTION
Currently there is the following compiler warning generated upon
building:
```console
../src/node_http2_core-inl.h:146:17: warning: comparison of integers of
different signs: 'ssize_t'
      (aka 'long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
      if (ncopy > buf.len)
          ~~~~~ ^ ~~~~~~~
```
ncopy is set to len which is of type ssize_t which is the return type of
nghttp2_session_mem_send, and there are checks to verify that len is
greater than zero so the converstion to size_t from ssize_t is safe.
ncopy can also be assigned to buf.len but uv_buf_t.len is of type
size_t.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2