### PR TITLE
http2: cast numchars to size_t

### DIFF
--- a/src/node_http2_core.cc
+++ b/src/node_http2_core.cc
@@ -201,7 +201,7 @@ ssize_t Nghttp2Session::OnStreamReadFD(nghttp2_session* session,
   stream->fd_offset_ += numchars;
 
   // if numchars < length, assume that we are done.
-  if (numchars < length) {
+  if (static_cast<size_t>(numchars) < length) {
     DEBUG_HTTP2("Nghttp2Session %d: no more data for stream %d\n",
                 handle->session_type_, id);
     *flags |= NGHTTP2_DATA_FLAG_EOF;


### PR DESCRIPTION
Currently when building the following compiler warning is issued:
```console
../src/node_http2_core.cc:204:16: warning: comparison of integers of
different signs: 'ssize_t'
      (aka 'long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  if (numchars < length) {
      ~~~~~~~~ ^ ~~~~~~
1 warning generated.
```
numchars is checked to make sure it is greater than 0 so it should be
safe to cast it to size_t.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
http2